### PR TITLE
Add zod shape utilities to work with snake case and still take adv of zod utilities

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { faker } from "@faker-js/faker"
-import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
+import { CamelCasedPropertiesDeep, SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import axios from "axios"
 import { beforeEach, describe, expect, it, Mocked, vi } from "vitest"
 import { z } from "zod"
-import { Pagination } from "./pagination"
 import { createApi, createCustomServiceCall, createPaginatedServiceCall } from "./api"
-import { getPaginatedSnakeCasedZod, GetInferredFromRaw, Prettify } from "./utils"
+import { Pagination } from "./pagination"
+import { GetInferredFromRaw, getPaginatedSnakeCasedZod, Prettify } from "./utils"
+import { ZodRawShapeToSnakedRecursive, zodToSnakeCaseRecursive } from "./utils/zod"
 
 vi.mock("axios")
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { faker } from "@faker-js/faker"
-import { CamelCasedPropertiesDeep, SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
+import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import axios from "axios"
 import { beforeEach, describe, expect, it, Mocked, vi } from "vitest"
 import { z } from "zod"
 import { createApi, createCustomServiceCall, createPaginatedServiceCall } from "./api"
 import { Pagination } from "./pagination"
 import { GetInferredFromRaw, getPaginatedSnakeCasedZod, Prettify } from "./utils"
-import { ZodRawShapeToSnakedRecursive, zodToSnakeCaseRecursive } from "./utils/zod"
 
 vi.mock("axios")
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -134,7 +134,7 @@ describe("objectToValidZodShape", () => {
   })
 })
 
-describe.only("zodToSnakeCaseShapeRecursive", () => {
+describe("zodToSnakeCaseShapeRecursive", () => {
   const myZod = z.object({
     stringZod: z.string(),
     objectZod: z.object({

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { CamelCasedPropertiesDeep } from "@thinknimble/tn-utils"
+import { CamelCasedPropertiesDeep, SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
 import { createApiUtils, GetInferredRecursiveShape, recursiveShapeToValidZodRawShape } from "./utils"
-import { ZodRawShapeToSnakedRecursive, zodToSnakeCaseRecursive } from "./utils/zod"
+import { ZodRawShapeToSnakedRecursive, zodObjectRecursive } from "./utils/zod"
 
 describe("createApiUtils", () => {
   it("returns undefined when both input output are primitives", () => {
@@ -134,37 +134,127 @@ describe("objectToValidZodShape", () => {
   })
 })
 
+const setupTest = <T extends z.ZodRawShape>(zodShape: T) => {
+  return zodObjectRecursive(z.object(zodShape))
+}
+
 describe("zodToSnakeCaseShapeRecursive", () => {
-  const myZod = z.object({
-    stringZod: z.string(),
-    objectZod: z.object({
-      numberZod: z.number(),
-    }),
-    arrayObjZod: z.array(
-      z.object({
-        elementOne: z.string(),
-        elementTwo: z.number(),
-      })
-    ),
-    arrayStringZod: z.array(z.string()),
+  const stringZod = z.string()
+  const objectZod = z.object({
+    numberZod: z.number(),
   })
-  const result = zodToSnakeCaseRecursive(myZod)
-  const { array_obj_zod, array_string_zod, object_zod, string_zod } = result.shape
+  const arrayObjZod = z.array(
+    z.object({
+      elementOne: z.string(),
+      elementTwo: z.number(),
+    })
+  )
+  const arrayStringZod = z.array(z.string())
+  const optionalObject = z
+    .object({
+      numberZod: z.number(),
+    })
+    .optional()
+  const optionalNestedObject = z
+    .object({
+      objectZod: z
+        .object({
+          stringZod: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional()
+  const optionalArrayString = arrayStringZod.optional()
+  const optionalArrayObject = arrayObjZod.optional()
+  const optionalArrayObjectNested = optionalNestedObject.array().optional()
+  const optionalStringZod = stringZod.optional()
+  const nullableObject = z
+    .object({
+      numberZod: z.number(),
+    })
+    .nullable()
+  const nullableNestedObject = z
+    .object({
+      objectZod: z
+        .object({
+          stringZod: z.string().nullable(),
+        })
+        .nullable(),
+    })
+    .nullable()
+  const nullableArrayString = arrayStringZod.nullable()
+  const nullableArrayObject = arrayObjZod.nullable()
+  const nullableArrayObjectNested = nullableNestedObject.array().nullable()
+  const nullableStringZod = stringZod.nullable()
+  const nullishNestedObject = z
+    .object({
+      objectZod: z
+        .object({
+          stringZod: z.string().nullish(),
+        })
+        .nullish(),
+    })
+    .nullish()
   it("Passes these ts tests", () => {
-    const result = myZod.shape
-    type ResultType = z.ZodObject<ZodRawShapeToSnakedRecursive<typeof result>>
-    type tests = [Expect<Equals<z.infer<typeof myZod>, CamelCasedPropertiesDeep<z.infer<ResultType>>>>]
+    //arrange
+    const myZod = z.object({
+      stringZod,
+      objectZod,
+      arrayObjZod,
+      arrayStringZod,
+      optionalObject,
+      optionalNestedObject,
+      optionalArrayString,
+      optionalArrayObject,
+      optionalArrayObjectNested,
+      nullableArrayString,
+      nullableArrayObject,
+      nullableArrayObjectNested,
+      nullableStringZod,
+      nullableObject,
+    })
+    type MyZod = z.infer<typeof myZod>
+    //act
+    const shape = myZod.shape
+    const result = setupTest(shape)
+    type ResultType = z.ZodObject<ZodRawShapeToSnakedRecursive<typeof shape>>
+    type ResultTypeOriginal = typeof result
+    //assert
+    //check both ways
+    type tests = [
+      Expect<Equals<MyZod, CamelCasedPropertiesDeep<z.infer<ResultType>>>>,
+      Expect<Equals<SnakeCasedPropertiesDeep<MyZod>, z.infer<ResultType>>>,
+      Expect<Equals<MyZod, CamelCasedPropertiesDeep<z.infer<ResultTypeOriginal>>>>,
+      Expect<Equals<SnakeCasedPropertiesDeep<MyZod>, z.infer<ResultTypeOriginal>>>
+    ]
   })
   it("Works on primitives", () => {
+    //arrange
+    //act
+    const { string_zod } = setupTest({
+      stringZod,
+    }).shape
+    //assert
     expect(string_zod).toBeInstanceOf(z.ZodString)
   })
   it("Works on simple objects", () => {
+    //arrange
+    //act
+    const { object_zod } = setupTest({
+      objectZod,
+    }).shape
+    //assert
     expect(object_zod).toBeInstanceOf(z.ZodObject)
     expect(object_zod.shape).toHaveProperty("number_zod")
     expect(object_zod.shape.number_zod).toBeInstanceOf(z.ZodNumber)
   })
   it("Works on object arrays", () => {
-    // const {arrayObjZod,arrayStringZod,objectZod,stringZod}  = myZod.shape
+    //arrange
+    //act
+    const { array_obj_zod } = setupTest({
+      arrayObjZod,
+    }).shape
+    //assert
     expect(array_obj_zod).toBeInstanceOf(z.ZodArray)
     expect(array_obj_zod.element).toBeInstanceOf(z.ZodObject)
     expect(array_obj_zod.element.shape).toHaveProperty("element_one")
@@ -173,12 +263,190 @@ describe("zodToSnakeCaseShapeRecursive", () => {
     expect(array_obj_zod.element.shape.element_two).toBeInstanceOf(z.ZodNumber)
   })
   it("Works on primitive arrays", () => {
+    //arrange
+    //act
+    const { array_string_zod } = setupTest({
+      arrayStringZod,
+    }).shape
+    //asert
     expect(array_string_zod).toBeInstanceOf(z.ZodArray)
     expect(array_string_zod.element).toBeInstanceOf(z.ZodString)
   })
   it("Works on nested objects", () => {
-    expect(array_string_zod).toBeInstanceOf(z.ZodArray)
-    expect(array_string_zod).toBeInstanceOf(z.ZodArray)
-    expect(array_string_zod).toBeInstanceOf(z.ZodArray)
+    //TODO:
+  })
+  it("Works on optional simple objects", () => {
+    //arrange
+    //act
+    const { object_zod_optional } = setupTest({
+      objectZodOptional: optionalObject,
+    }).shape
+    //assert
+    expect(object_zod_optional).toBeInstanceOf(z.ZodOptional)
+    expect(object_zod_optional.unwrap()).toBeInstanceOf(z.ZodObject)
+    expect(object_zod_optional.unwrap().shape).toHaveProperty("number_zod")
+  })
+  it("Works on optional nested objects", () => {
+    //arrange
+    //act
+    const { nested_object_zod_optional } = setupTest({
+      nestedObjectZodOptional: optionalNestedObject,
+    }).shape
+    //assert
+    expect(nested_object_zod_optional).toBeInstanceOf(z.ZodOptional)
+    const unwrappedShape = nested_object_zod_optional.unwrap().shape
+    expect(unwrappedShape).toHaveProperty("object_zod")
+    expect(unwrappedShape.object_zod).toBeInstanceOf(z.ZodOptional)
+    const unwrappedNestedShape = unwrappedShape.object_zod.unwrap().shape
+    expect(unwrappedNestedShape).toHaveProperty("string_zod")
+    expect(unwrappedNestedShape.string_zod).toBeInstanceOf(z.ZodOptional)
+    expect(unwrappedNestedShape.string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("Works on optional array", () => {
+    //arrange
+    //act
+    const { optional_array_object } = setupTest({
+      optionalArrayObject,
+    }).shape
+    //assert
+    expect(optional_array_object).toBeInstanceOf(z.ZodOptional)
+    const unwrapped = optional_array_object.unwrap()
+    expect(unwrapped).toBeInstanceOf(z.ZodArray)
+    expect(unwrapped.element).toBeInstanceOf(z.ZodObject)
+    expect(unwrapped.element.shape).toHaveProperty("element_one")
+    expect(unwrapped.element.shape.element_one).toBeInstanceOf(z.ZodString)
+    expect(unwrapped.element.shape).toHaveProperty("element_two")
+    expect(unwrapped.element.shape.element_two).toBeInstanceOf(z.ZodNumber)
+  })
+  it("Works on optional primitive", () => {
+    //arrange
+    //act
+    const { optional_string_zod } = setupTest({
+      optionalStringZod,
+    }).shape
+    //assert
+    expect(optional_string_zod).toBeInstanceOf(z.ZodOptional)
+    expect(optional_string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("Works on optional nested objects array", () => {
+    //arrange
+    //act
+    const { optional_array_object_nested } = setupTest({
+      optionalArrayObjectNested,
+    }).shape
+    //assert
+    expect(optional_array_object_nested).toBeInstanceOf(z.ZodOptional)
+    const unwrapped = optional_array_object_nested.unwrap()
+    expect(unwrapped).toBeInstanceOf(z.ZodArray)
+    expect(unwrapped.element).toBeInstanceOf(z.ZodOptional)
+    const unwrappedElement = unwrapped.element.unwrap()
+    expect(unwrappedElement).toBeInstanceOf(z.ZodObject)
+    expect(unwrappedElement.shape).toHaveProperty("object_zod")
+    const object_zod = unwrappedElement.shape.object_zod
+    expect(object_zod).toBeInstanceOf(z.ZodOptional)
+    expect(object_zod.unwrap()).toBeInstanceOf(z.ZodObject)
+    expect(object_zod.unwrap().shape).toHaveProperty("string_zod")
+    const string_zod = object_zod.unwrap().shape.string_zod
+    expect(string_zod).toBeInstanceOf(z.ZodOptional)
+    expect(string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("works on nullable simple objects", () => {
+    //arrange
+    const { nullable_object } = setupTest({
+      nullableObject,
+    }).shape
+
+    expect(nullable_object).toBeInstanceOf(z.ZodNullable)
+    const unwrapped = nullable_object.unwrap()
+    expect(unwrapped).toBeInstanceOf(z.ZodObject)
+    expect(unwrapped.shape).toHaveProperty("number_zod")
+    expect(unwrapped.shape.number_zod).toBeInstanceOf(z.ZodNumber)
+  })
+  it("Works on nullable nested objects", () => {
+    //arrange
+    //act
+    const { nullable_nested_object } = setupTest({
+      nullableNestedObject,
+    }).shape
+    //assert
+    expect(nullable_nested_object).toBeInstanceOf(z.ZodNullable)
+    const unwrappedShape = nullable_nested_object.unwrap().shape
+    expect(unwrappedShape).toHaveProperty("object_zod")
+    expect(unwrappedShape.object_zod).toBeInstanceOf(z.ZodNullable)
+    const unwrappedNestedShape = unwrappedShape.object_zod.unwrap().shape
+    expect(unwrappedNestedShape).toHaveProperty("string_zod")
+    expect(unwrappedNestedShape.string_zod).toBeInstanceOf(z.ZodNullable)
+    expect(unwrappedNestedShape.string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("Works on nullable array", () => {
+    //arrange
+    //act
+    const { nullable_array_object } = setupTest({
+      nullableArrayObject,
+    }).shape
+    //assert
+    expect(nullable_array_object).toBeInstanceOf(z.ZodNullable)
+    const unwrapped = nullable_array_object.unwrap()
+    expect(unwrapped).toBeInstanceOf(z.ZodArray)
+    expect(unwrapped.element).toBeInstanceOf(z.ZodObject)
+    expect(unwrapped.element.shape).toHaveProperty("element_one")
+    expect(unwrapped.element.shape.element_one).toBeInstanceOf(z.ZodString)
+    expect(unwrapped.element.shape).toHaveProperty("element_two")
+    expect(unwrapped.element.shape.element_two).toBeInstanceOf(z.ZodNumber)
+  })
+  it("Works on nullable primitive", () => {
+    //arrange
+    //act
+    const { nullable_string_zod } = setupTest({
+      nullableStringZod,
+    }).shape
+    //assert
+    expect(nullable_string_zod).toBeInstanceOf(z.ZodNullable)
+    expect(nullable_string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("Works on nullable nested objects array", () => {
+    //arrange
+    //act
+    const { nullable_array_object_nested } = setupTest({
+      nullableArrayObjectNested,
+    }).shape
+    //assert
+    expect(nullable_array_object_nested).toBeInstanceOf(z.ZodNullable)
+    const unwrapped = nullable_array_object_nested.unwrap()
+    expect(unwrapped).toBeInstanceOf(z.ZodArray)
+    expect(unwrapped.element).toBeInstanceOf(z.ZodNullable)
+    const unwrappedElement = unwrapped.element.unwrap()
+    expect(unwrappedElement).toBeInstanceOf(z.ZodObject)
+    expect(unwrappedElement.shape).toHaveProperty("object_zod")
+    const object_zod = unwrappedElement.shape.object_zod
+    expect(object_zod).toBeInstanceOf(z.ZodNullable)
+    expect(object_zod.unwrap()).toBeInstanceOf(z.ZodObject)
+    expect(object_zod.unwrap().shape).toHaveProperty("string_zod")
+    const string_zod = object_zod.unwrap().shape.string_zod
+    expect(string_zod).toBeInstanceOf(z.ZodNullable)
+    expect(string_zod.unwrap()).toBeInstanceOf(z.ZodString)
+  })
+  it("Works on nullish object", () => {
+    //nullish is a combination of zod optional and zod nullable so if those two work, we should be able to make nullish work
+    const { nullish_nested_object } = setupTest({
+      nullishNestedObject,
+    }).shape
+
+    expect(nullish_nested_object).toBeInstanceOf(z.ZodOptional)
+    const optionalUnwrapped = nullish_nested_object.unwrap()
+    expect(optionalUnwrapped).toBeInstanceOf(z.ZodNullable)
+    const nullableUnwrapped = optionalUnwrapped.unwrap()
+    expect(nullableUnwrapped).toBeInstanceOf(z.ZodObject)
+    expect(nullableUnwrapped.shape).toHaveProperty("object_zod")
+    expect(nullableUnwrapped.shape.object_zod).toBeInstanceOf(z.ZodOptional)
+    const nullishObjectUnwrapped = nullableUnwrapped.shape.object_zod.unwrap()
+    expect(nullishObjectUnwrapped).toBeInstanceOf(z.ZodNullable)
+    const nextUnwrapped = nullishObjectUnwrapped.unwrap()
+    expect(nextUnwrapped).toBeInstanceOf(z.ZodObject)
+    expect(nextUnwrapped.shape).toHaveProperty("string_zod")
+    expect(nextUnwrapped.shape.string_zod).toBeInstanceOf(z.ZodOptional)
+    const optionalStringZodUnwrapped = nextUnwrapped.shape.string_zod.unwrap()
+    expect(optionalStringZodUnwrapped).toBeInstanceOf(z.ZodNullable)
+    expect(optionalStringZodUnwrapped.unwrap()).toBeInstanceOf(z.ZodString)
   })
 })

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,45 +1,109 @@
 import { SnakeCase, toSnakeCase } from "@thinknimble/tn-utils"
 import { z } from "zod"
 
-export const zodArrayToShape = <T extends z.ZodRawShape>(zodArray: z.ZodArray<z.ZodObject<T>>) => {
-  return zodArray._def.type._def.shape()
-}
-export const isZodArray = (input: unknown): input is z.ZodArray<any> => {
+export const isZodArray = (input: z.ZodTypeAny): input is z.ZodArray<z.ZodTypeAny> => {
   return input instanceof z.ZodArray
 }
-export const isZodObject = (input: unknown): input is z.ZodObject<any> => {
+export const isZodObject = (input: z.ZodTypeAny): input is z.ZodObject<z.ZodRawShape> => {
   return input instanceof z.ZodObject
 }
-type InferShape<T extends z.ZodObject<z.ZodRawShape>> = T extends z.ZodObject<infer Obj> ? Obj : never
+export const isZodOptional = (input: z.ZodTypeAny): input is z.ZodOptional<z.ZodTypeAny> => {
+  return input.isOptional()
+}
+export const isZodNullable = (input: z.ZodTypeAny): input is z.ZodNullable<z.ZodTypeAny> => {
+  return input.isNullable()
+}
 
-// I'm a bit concerned about what this will look like and how will this work.
+type InferZodArray<T extends z.ZodArray<z.ZodTypeAny>> = T extends z.ZodArray<infer TEl>
+  ? z.ZodArray<ZodRecursiveResult<TEl>>
+  : never
+
+type InferZodObject<T extends z.ZodObject<z.ZodRawShape>> = T extends z.ZodObject<infer TZodObj>
+  ? z.ZodObject<ZodRawShapeToSnakedRecursive<TZodObj>>
+  : never
+
+type InferZodOptional<T extends z.ZodOptional<z.ZodTypeAny>> = T extends z.ZodOptional<infer TOpt>
+  ? z.ZodOptional<ZodRecursiveResult<TOpt>>
+  : never
+
+type InferZodNullable<T extends z.ZodNullable<z.ZodTypeAny>> = T extends z.ZodNullable<infer TNull>
+  ? z.ZodNullable<ZodRecursiveResult<TNull>>
+  : never
+
+/**
+ * Determine the type of processing a zod shape into its snake cased equivalent
+ */
 export type ZodRawShapeToSnakedRecursive<T extends z.ZodRawShape> = {
-  [K in keyof T as SnakeCase<K>]: T[K] extends z.ZodObject<z.ZodRawShape>
-    ? z.ZodObject<ZodRawShapeToSnakedRecursive<InferShape<T[K]>>>
-    : T[K] extends z.ZodArray<infer El>
-    ? El extends z.ZodObject<z.ZodRawShape>
-      ? z.ZodArray<z.ZodObject<ZodRawShapeToSnakedRecursive<InferShape<El>>>>
-      : T[K]
+  [K in keyof T as SnakeCase<K>]: T[K] extends z.ZodRawShape
+    ? never
+    : T[K] extends z.ZodOptional<z.ZodTypeAny>
+    ? InferZodOptional<T[K]>
+    : //check whether it is array or object, else just default to its type
+    T[K] extends z.ZodNullable<z.ZodTypeAny>
+    ? InferZodNullable<T[K]>
+    : T[K] extends z.ZodObject<z.ZodRawShape>
+    ? InferZodObject<T[K]>
+    : T[K] extends z.ZodArray<z.ZodTypeAny>
+    ? InferZodArray<T[K]>
     : T[K]
+}
+type ZodRecursiveResult<T extends z.ZodTypeAny> = T extends z.ZodObject<z.ZodRawShape>
+  ? InferZodObject<T>
+  : T extends z.ZodArray<z.ZodTypeAny>
+  ? InferZodArray<T>
+  : T extends z.ZodOptional<z.ZodTypeAny>
+  ? InferZodOptional<T>
+  : T extends z.ZodNullable<z.ZodTypeAny>
+  ? InferZodNullable<T>
+  : T
+
+function resolveRecursiveZod<T extends z.ZodTypeAny>(zod: T) {
+  //: ZodRecursiveResult<T>
+  if (isZodObject(zod)) {
+    return zodObjectRecursive(zod)
+  }
+  if (isZodArray(zod)) {
+    return zodArrayRecursive(zod)
+  }
+  if (isZodOptional(zod)) {
+    return zodOptionalRecursive(zod)
+  }
+  if (isZodNullable(zod)) {
+    return zodNullableRecursive(zod)
+  }
+  return zod
+}
+
+//! could not escape of these any here. in the three functions below
+function zodArrayRecursive<T extends z.ZodTypeAny>(zodArray: z.ZodArray<T>): any {
+  //: InferZodArray<z.ZodArray<T>>
+  const innerElement = zodArray.element
+
+  return resolveRecursiveZod(innerElement).array()
+}
+
+function zodNullableRecursive<T extends z.ZodTypeAny>(zodNullable: z.ZodNullable<T>): any {
+  // : InferZodNullable<z.ZodNullable<T>>
+  const unwrapped = zodNullable.unwrap()
+  return resolveRecursiveZod(unwrapped).nullable()
+}
+
+function zodOptionalRecursive<T extends z.ZodTypeAny>(zodOptional: z.ZodOptional<T>): any {
+  // : InferZodOptional<z.ZodOptional<T>>
+  const unwrapped = zodOptional.unwrap()
+  return resolveRecursiveZod(unwrapped).optional()
 }
 
 /**
  * Recursively convert a zod object into its snake_cased equivalent
  */
-export const zodToSnakeCaseRecursive = <T extends z.ZodRawShape>(
+export function zodObjectRecursive<T extends z.ZodRawShape>(
   zodObj: z.ZodObject<T>
-): z.ZodObject<ZodRawShapeToSnakedRecursive<T>> => {
+): z.ZodObject<ZodRawShapeToSnakedRecursive<T>> {
   const resultingShape = Object.fromEntries(
     Object.entries(zodObj.shape).map(([k, v]) => {
       const snakeCasedKey = toSnakeCase(k)
-      if (isZodObject(v)) {
-        return [snakeCasedKey, zodToSnakeCaseRecursive(v)]
-      }
-      if (isZodArray(v) && isZodObject(v.element)) {
-        return [snakeCasedKey, z.array(zodToSnakeCaseRecursive(v.element))]
-      }
-      //then V is another ZodType which we don't care to address right now
-      return [snakeCasedKey, v]
+      return [snakeCasedKey, resolveRecursiveZod(v)]
     })
   ) as ZodRawShapeToSnakedRecursive<T>
   return z.object(resultingShape)

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,0 +1,46 @@
+import { SnakeCase, toSnakeCase } from "@thinknimble/tn-utils"
+import { z } from "zod"
+
+export const zodArrayToShape = <T extends z.ZodRawShape>(zodArray: z.ZodArray<z.ZodObject<T>>) => {
+  return zodArray._def.type._def.shape()
+}
+export const isZodArray = (input: unknown): input is z.ZodArray<any> => {
+  return input instanceof z.ZodArray
+}
+export const isZodObject = (input: unknown): input is z.ZodObject<any> => {
+  return input instanceof z.ZodObject
+}
+type InferShape<T extends z.ZodObject<z.ZodRawShape>> = T extends z.ZodObject<infer Obj> ? Obj : never
+
+// I'm a bit concerned about what this will look like and how will this work.
+export type ZodRawShapeToSnakedRecursive<T extends z.ZodRawShape> = {
+  [K in keyof T as SnakeCase<K>]: T[K] extends z.ZodObject<z.ZodRawShape>
+    ? z.ZodObject<ZodRawShapeToSnakedRecursive<InferShape<T[K]>>>
+    : T[K] extends z.ZodArray<infer El>
+    ? El extends z.ZodObject<z.ZodRawShape>
+      ? z.ZodArray<z.ZodObject<ZodRawShapeToSnakedRecursive<InferShape<El>>>>
+      : T[K]
+    : T[K]
+}
+
+/**
+ * Recursively convert a zod object into its snake_cased equivalent
+ */
+export const zodToSnakeCaseRecursive = <T extends z.ZodRawShape>(
+  zodObj: z.ZodObject<T>
+): z.ZodObject<ZodRawShapeToSnakedRecursive<T>> => {
+  const resultingShape = Object.fromEntries(
+    Object.entries(zodObj.shape).map(([k, v]) => {
+      const snakeCasedKey = toSnakeCase(k)
+      if (isZodObject(v)) {
+        return [snakeCasedKey, zodToSnakeCaseRecursive(v)]
+      }
+      if (isZodArray(v) && isZodObject(v.element)) {
+        return [snakeCasedKey, z.array(zodToSnakeCaseRecursive(v.element))]
+      }
+      //then V is another ZodType which we don't care to address right now
+      return [snakeCasedKey, v]
+    })
+  ) as ZodRawShapeToSnakedRecursive<T>
+  return z.object(resultingShape)
+}


### PR DESCRIPTION
## What this does
- add initial work and tests for zod recursive util.

## Checklist
- [x] Add support for plain zods
- [x] Add support for `nullish`
- [x] Add supoprt `optional`
- [x] Add support for `nullable`
- [x] Add support for `and`
- [x] Add support for `or`
- [x] Tests

Addresses core functionality of #29 

## Descoped zod utilities:
- `default`
- `catch` 
- `refine` or any of the other `ZodEffects`
- `pipe`
