### PR TITLE
Fix `fromApi` using the wrong zod to parse response warning

### DIFF
--- a/.changeset/sweet-kangaroos-speak.md
+++ b/.changeset/sweet-kangaroos-speak.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+Fix fromApi not using the right zod to compare

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -86,12 +86,13 @@ const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives>(outputSha
   // since this checks for the api response, which we don't control, we can't strict parse, else we would break the flow. We'd rather safe parse and show a warning if there's a mismatch
   return isOutputZodPrimitive
     ? undefined
-    : (((obj: object) =>
-        parseResponse({
+    : (((obj: object) => {
+        return parseResponse({
           identifier: callerName,
           data: objectToCamelCase(obj) ?? {},
-          zod: zodObjectRecursive(z.object(outputShape)),
-        })) as FromApiCall<T>)
+          zod: z.object(outputShape),
+        })
+      }) as FromApiCall<T>)
 }
 
 export function createApiUtils<

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -86,6 +86,43 @@ describe("createApiUtils", () => {
     expect("toApi" in utils).toEqual(true)
     expect("fromApi" in utils).toEqual(true)
   })
+  it("fromApi makes the right key conversion", () => {
+    //arrange
+    const { utils } = createApiUtils({
+      outputShape: {
+        testBoolean: z.boolean(),
+      },
+      name: "fromApi",
+    })
+    const input = {
+      test_boolean: false,
+    }
+    //act
+    const trial = utils.fromApi(input)
+    //assert
+    expect(trial).toEqual({
+      testBoolean: false,
+    })
+  })
+
+  it("toApi makes the right key conversion", () => {
+    //arrange
+    const { utils } = createApiUtils({
+      inputShape: {
+        testBoolean: z.boolean(),
+      },
+      name: "toApi",
+    })
+    const input = {
+      testBoolean: false,
+    }
+    //act
+    const trial = utils.toApi(input)
+    //assert
+    expect(trial).toEqual({
+      test_boolean: false,
+    })
+  })
 })
 
 const setupTest = <T extends z.ZodRawShape>(zodShape: T) => {


### PR DESCRIPTION
## What this does
- Fix wrong zod on fromApi util
- Add basic tests for fromApi and toApi