### PR TITLE
Warn users if their uris are not slash-ended

### DIFF
--- a/.changeset/dry-dogs-glow.md
+++ b/.changeset/dry-dogs-glow.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": minor
+---
+
+Add type-wrapper to axios client provided in `createCustomServiceCall` argument so that we make sure users pass a slash ending uri rather than any string. This has some caveats that have been updated in our README

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ To do this you pass an object with the service callbacks. These should be create
 
 First parameter are the models for your input and output shapes of the call.
 
-Second parameter is the actual service call, this callback is powered up with multiple arguments that provide you with all the tools we think you need to make a type-safe call.
+Second parameter is the actual service call, this callback is powered up with multiple arguments that provide you with all the tools we think you need to make a type-safe call:
 
 ```typescript
 const updatePartial = createCustomServiceCall(
@@ -275,6 +275,31 @@ export const todoApi = createApi(
 ```
 
 We also added a `csc` alias in case you feel `customServiceCall` is too long.
+
+### On the service callback parameters
+
+We provide a set of parameters in the custom service callback:
+
+- client: a type-wrapped axios instance that makes sure you call the apis with slash ending uris.
+
+For this client to consume your uri strings you should either cast them `as const` or define them as template strings directly in the call
+
+```typescript
+  client.get(`${slashEndingBaseUri}`) // slashEndingBaseUri is an `as const` variable
+  client.get(`${slashEndingBaseUri}/ending/`) // ✅ define the template string directly in the function call
+
+  const uriSampleOutsideOfCall =`${slashEndingBaseUri}my-uri/not-const/`
+  client.get(uriSample)// ❌ this does not check, you'll get error, template string is already evaluated outside so it is considered `string`
+
+  const uriSampleOutsideOfCallAsConst = `${slashEndingBaseUri}my-uri/not-const/` as const
+  client get(uriSampleOutsideOfCallAsConst)//s checks, since it was cast as const outside of the call
+```
+
+- slashEndingBaseUri: gives you a reference to the endpoint you passed when you created the api so you can use it within the callback
+- input:the parsed input based on the `inputShape` you passed
+- utils: set of utilities to convert from and to api models (handles object casing)
+  - fromApi: convert a response object from the api (coming in snake casing) to its camelCase version
+  - toApi: convert an input into an snake_cased object so that you can feed it to the api.
 
 ## `createPaginatedServiceCall`
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.3",
     "tsup": "^6.6.3",
-    "typescript": "^4.9.5",
+    "typescript": "^5.0.2",
     "vite": "^4.0.4",
     "vitest": "^0.27.3",
     "zod": "^3.21.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ specifiers:
   eslint-plugin-prettier: ^4.2.1
   prettier: ^2.8.3
   tsup: ^6.6.3
-  typescript: ^4.9.5
+  typescript: ^5.0.2
   vite: ^4.0.4
   vitest: ^0.27.3
   zod: ^3.21.4
@@ -23,15 +23,15 @@ dependencies:
 devDependencies:
   '@changesets/cli': 2.26.0
   '@faker-js/faker': 7.6.0
-  '@typescript-eslint/eslint-plugin': 5.54.1_4rfaf6mlw2mmutqjcopwvbftpu
-  '@typescript-eslint/parser': 5.54.1_vgl77cfdswitgr47lm5swmv43m
+  '@typescript-eslint/eslint-plugin': 5.54.1_k4rdtyz2uuo3tzblkqed7c56rq
+  '@typescript-eslint/parser': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
   axios: 1.3.4
   eslint: 8.36.0
   eslint-config-prettier: 8.7.0_eslint@8.36.0
   eslint-plugin-prettier: 4.2.1_eqzx3hpkgx5nnvxls3azrcc7dm
   prettier: 2.8.4
-  tsup: 6.6.3_typescript@4.9.5
-  typescript: 4.9.5
+  tsup: 6.6.3_typescript@5.0.2
+  typescript: 5.0.2
   vite: 4.1.4
   vitest: 0.27.3
   zod: 3.21.4
@@ -799,7 +799,7 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.54.1_4rfaf6mlw2mmutqjcopwvbftpu:
+  /@typescript-eslint/eslint-plugin/5.54.1_k4rdtyz2uuo3tzblkqed7c56rq:
     resolution: {integrity: sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -810,10 +810,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.54.1_vgl77cfdswitgr47lm5swmv43m
+      '@typescript-eslint/parser': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
       '@typescript-eslint/scope-manager': 5.54.1
-      '@typescript-eslint/type-utils': 5.54.1_vgl77cfdswitgr47lm5swmv43m
-      '@typescript-eslint/utils': 5.54.1_vgl77cfdswitgr47lm5swmv43m
+      '@typescript-eslint/type-utils': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
+      '@typescript-eslint/utils': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
       debug: 4.3.4
       eslint: 8.36.0
       grapheme-splitter: 1.0.4
@@ -821,13 +821,13 @@ packages:
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.54.1_vgl77cfdswitgr47lm5swmv43m:
+  /@typescript-eslint/parser/5.54.1_j4766f7ecgqbon3u7zlxn5zszu:
     resolution: {integrity: sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -839,10 +839,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.54.1
       '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.2
       debug: 4.3.4
       eslint: 8.36.0
-      typescript: 4.9.5
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -855,7 +855,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.54.1
     dev: true
 
-  /@typescript-eslint/type-utils/5.54.1_vgl77cfdswitgr47lm5swmv43m:
+  /@typescript-eslint/type-utils/5.54.1_j4766f7ecgqbon3u7zlxn5zszu:
     resolution: {integrity: sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -865,12 +865,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
-      '@typescript-eslint/utils': 5.54.1_vgl77cfdswitgr47lm5swmv43m
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.2
+      '@typescript-eslint/utils': 5.54.1_j4766f7ecgqbon3u7zlxn5zszu
       debug: 4.3.4
       eslint: 8.36.0
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -880,7 +880,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.54.1_typescript@4.9.5:
+  /@typescript-eslint/typescript-estree/5.54.1_typescript@5.0.2:
     resolution: {integrity: sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -895,13 +895,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.5
-      typescript: 4.9.5
+      tsutils: 3.21.0_typescript@5.0.2
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.54.1_vgl77cfdswitgr47lm5swmv43m:
+  /@typescript-eslint/utils/5.54.1_j4766f7ecgqbon3u7zlxn5zszu:
     resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -911,7 +911,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.54.1
       '@typescript-eslint/types': 5.54.1
-      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@5.0.2
       eslint: 8.36.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.36.0
@@ -3226,7 +3226,7 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsup/6.6.3_typescript@4.9.5:
+  /tsup/6.6.3_typescript@5.0.2:
     resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -3256,20 +3256,20 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.29.0
       tree-kill: 1.2.2
-      typescript: 4.9.5
+      typescript: 5.0.2
     transitivePeerDependencies:
       - supports-color
       - ts-node
     dev: true
 
-  /tsutils/3.21.0_typescript@4.9.5:
+  /tsutils/3.21.0_typescript@5.0.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.0.2
     dev: true
 
   /tty-table/4.1.6:
@@ -3331,9 +3331,9 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typescript/4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
+  /typescript/5.0.2:
+    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -258,17 +258,16 @@ const testPostPaginatedServiceCall = (() => {
 const testSlashEndingUri = createCustomServiceCall(async ({ client, slashEndingBaseUri }) => {
   type TClient = typeof client
   type UriParameter = Parameters<TClient["get"]>[0]
-  const templateStringNonSlashEndingUri = `${slashEndingBaseUri}/slashEndingUri`
-  const templateStringSlashEndingUri = `${slashEndingBaseUri}${templateStringNonSlashEndingUri}/`
   type tests = [
     Expect<Equals<UriParameter, typeof slashEndingBaseUri>>,
     Expect<Extends<UriParameter, `slashEndinguri/`>>,
     //@ts-expect-error non slash ending uri should error on ts
     Expect<Extends<UriParameter, `nonSlashEnding`>>
   ]
-  client.get(`${templateStringNonSlashEndingUri}/`)
-  //TODO: okay this should not error...
-  client.get(templateStringSlashEndingUri)
+  //@ts-expect-error should error bc we're not ending the url with a slash
+  client.get(`${slashEndingBaseUri}/slashEndingUri`)
+  client.get(`${slashEndingBaseUri}`)
+  client.get(`${slashEndingBaseUri}/ending/`)
 })
 
 describe("v2 api tests", async () => {

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -255,6 +255,22 @@ const testPostPaginatedServiceCall = (() => {
   )
 })()
 
+const testSlashEndingUri = createCustomServiceCall(async ({ client, slashEndingBaseUri }) => {
+  type TClient = typeof client
+  type UriParameter = Parameters<TClient["get"]>[0]
+  const templateStringNonSlashEndingUri = `${slashEndingBaseUri}/slashEndingUri`
+  const templateStringSlashEndingUri = `${slashEndingBaseUri}${templateStringNonSlashEndingUri}/`
+  type tests = [
+    Expect<Equals<UriParameter, typeof slashEndingBaseUri>>,
+    Expect<Extends<UriParameter, `slashEndinguri/`>>,
+    //@ts-expect-error non slash ending uri should error on ts
+    Expect<Extends<UriParameter, `nonSlashEnding`>>
+  ]
+  client.get(`${templateStringNonSlashEndingUri}/`)
+  //TODO: okay this should not error...
+  client.get(templateStringSlashEndingUri)
+})
+
 describe("v2 api tests", async () => {
   const testBaseUri = "users"
   const testApi = createApi(

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -640,7 +640,7 @@ describe("v2 api tests", async () => {
       })
       //act
       await testApi.csc.testSimplePaginatedCall({ pagination: new Pagination({ page: 1 }) })
-      expect(getSpy).toHaveBeenCalledWith(`${testBaseUri}/testSimplePaginatedCall`, {
+      expect(getSpy).toHaveBeenCalledWith(`${testBaseUri}/testSimplePaginatedCall/`, {
         params: {
           page: "1",
           page_size: "25",
@@ -667,7 +667,7 @@ describe("v2 api tests", async () => {
       await testApi.csc.testPostPaginatedServiceCall({ ...body, pagination: new Pagination({ page: 1 }) })
       //assert
       expect(getSpy).not.toHaveBeenCalled()
-      expect(postSpy).toHaveBeenCalledWith(`${testBaseUri}/testPostPaginatedServiceCall`, body, {
+      expect(postSpy).toHaveBeenCalledWith(`${testBaseUri}/testPostPaginatedServiceCall/`, body, {
         params: {
           page: "1",
           page_size: "25",
@@ -689,7 +689,7 @@ describe("v2 api tests", async () => {
       //act
       await testApi.csc.testPagePaginatedServiceCall({ pagination: new Pagination({ page: 10, size: 100 }) })
       //assert
-      expect(getSpy).toHaveBeenCalledWith(`${testBaseUri}/testPagePaginatedServiceCall`, {
+      expect(getSpy).toHaveBeenCalledWith(`${testBaseUri}/testPagePaginatedServiceCall/`, {
         params: {
           page: "10",
           page_size: "100",

--- a/src/api/create-paginated-call.ts
+++ b/src/api/create-paginated-call.ts
@@ -72,8 +72,8 @@ export function createPaginatedServiceCall<TOutput extends z.ZodRawShape, TInput
       : undefined
 
     let res
-    //TODO: add check for trailing slash
-    const fullUri = `${slashEndingBaseUri}${uri}`
+    const slashEndingUri = uri[uri.length - 1] === "/" ? uri : uri + "/"
+    const fullUri = `${slashEndingBaseUri}${slashEndingUri}` as `${string}/`
     if (httpMethod === "get") {
       res = await client.get(fullUri, {
         params: snakedCleanParsedFilters,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,4 +1,4 @@
-import { AxiosInstance } from "axios"
+import { AxiosRequestConfig, AxiosResponse } from "axios"
 import { z } from "zod"
 import { CallbackUtils, GetInferredFromRaw, ZodPrimitives } from "../utils"
 
@@ -23,13 +23,37 @@ type CallbackInput<TInput extends z.ZodRawShape | ZodPrimitives> = TInput extend
       input: InferCallbackInput<TInput>
     }
 
+type ExpectTrailingSlash<T extends string> = T extends `${string}/` ? T : "Include a triling slash in the uri"
+
+type AxiosCall = <T = any, R = AxiosResponse<T>, D = any, TUri extends string = string>(
+  url: ExpectTrailingSlash<TUri>,
+  config?: AxiosRequestConfig<D>
+) => Promise<R>
+type BodyAxiosCall = <T = any, R = AxiosResponse<T>, D = any, TUri extends string = string>(
+  url: ExpectTrailingSlash<TUri>,
+  data?: D,
+  config?: AxiosRequestConfig<D>
+) => Promise<R>
+
+export type AxiosLike = {
+  get: AxiosCall
+  post: BodyAxiosCall
+  delete: AxiosCall
+  put: BodyAxiosCall
+  patch: BodyAxiosCall
+  options: AxiosCall
+  postForm: BodyAxiosCall
+  putForm: BodyAxiosCall
+  patchForm: BodyAxiosCall
+}
+
 export type CustomServiceCallback<
   TInput extends z.ZodRawShape | ZodPrimitives = z.ZodVoid,
   TOutput extends z.ZodRawShape | ZodPrimitives = z.ZodVoid
 > = (
   params: {
-    client: AxiosInstance
-    slashEndingBaseUri: string
+    client: AxiosLike
+    slashEndingBaseUri: `${string}/`
   } & CallbackUtils<TInput, TOutput> &
     CallbackInput<TInput>
 ) => Promise<

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -23,14 +23,13 @@ type CallbackInput<TInput extends z.ZodRawShape | ZodPrimitives> = TInput extend
       input: InferCallbackInput<TInput>
     }
 
-type ExpectTrailingSlash<T extends string> = T extends `${string}/` ? T : "Include a triling slash in the uri"
-
-type AxiosCall = <T = any, R = AxiosResponse<T>, D = any, TUri extends string = string>(
-  url: ExpectTrailingSlash<TUri>,
+type StringTrailingSlash = `${string}/`
+type AxiosCall = <TUri extends StringTrailingSlash, T = any, R = AxiosResponse<T>, D = any>(
+  url: TUri,
   config?: AxiosRequestConfig<D>
 ) => Promise<R>
-type BodyAxiosCall = <T = any, R = AxiosResponse<T>, D = any, TUri extends string = string>(
-  url: ExpectTrailingSlash<TUri>,
+type BodyAxiosCall = <TUri extends StringTrailingSlash, T = any, R = AxiosResponse<T>, D = any>(
+  url: StringTrailingSlash,
   data?: D,
   config?: AxiosRequestConfig<D>
 ) => Promise<R>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,3 @@
 declare type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false
 declare type Expect<T extends true> = T
+declare type Extends<T1, T2> = T2 extends T1 ? true : false


### PR DESCRIPTION
~- I am yet to be able to find a way to improve this, it does not work properly as it is we need the  user to cast as const whatever they pass which is BS.~

This might be ready I want to ponder a little more on whether this is a good approach or not. Probably will do a release with this, check it out whether it is more a pain than a solution and if that is so I would revert it.

Would: 
- Closes #45 