### PR TITLE
Hotfix `objectToCamelCaseArr` crashing on null values

### DIFF
--- a/.changeset/twenty-months-share.md
+++ b/.changeset/twenty-months-share.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+Fix issue with nulls being considered of type object in js. Mischeck was crashing library on null values

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -82,7 +82,7 @@ export type CallbackUtils<
 
 //TODO: this should probably move to tn-utils but will keep it here for a quick release
 export const objectToCamelCaseArr = <T extends object>(obj: T): CamelCasedPropertiesDeep<T> => {
-  if (typeof obj !== "object") return obj
+  if (typeof obj !== "object" || obj === null) return obj
   if (Array.isArray(obj)) return obj.map((o) => objectToCamelCaseArr(o)) as CamelCasedPropertiesDeep<T>
   const entries = Object.entries(obj)
   const newEntries = []


### PR DESCRIPTION
I missed a check to rule out the possibility of a variable being null.

`null` is considered of type `object` so my filter (`typeof obj === 'object'`) was not enough to discard `null` as a possibility.

Closes #65 