### PR TITLE
Infer `id` from entity shape rather than assuming `string`

### DIFF
--- a/.changeset/slow-books-jam.md
+++ b/.changeset/slow-books-jam.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": minor
+---
+
+Allow ids to be of type string or number and infer them properly in the corresponding inputs from built-in methods. Improve branded types resolution of return types from built-in methods.

--- a/src/api/tests/mocks.ts
+++ b/src/api/tests/mocks.ts
@@ -18,6 +18,10 @@ export const entityZodShape = {
   id: z.string().uuid(),
   fullName: readonly(z.string()),
 }
+export const entityZodShapeWithIdNumber = {
+  ...entityZodShape,
+  id: z.number(),
+}
 
 type Entity = GetInferredFromRaw<typeof entityZodShape>
 

--- a/src/collection-manager/collection-manager.test.ts
+++ b/src/collection-manager/collection-manager.test.ts
@@ -1,12 +1,11 @@
 import { faker } from "@faker-js/faker"
 import { objectToCamelCase, objectToSnakeCase } from "@thinknimble/tn-utils"
 import axios from "axios"
-import { beforeEach, describe, expect, it, Mocked, vi } from "vitest"
+import { Mocked, beforeEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { Pagination } from "../utils/pagination"
-import { createApi } from "../api"
 import { createCollectionManager } from "."
-import { getPaginatedSnakeCasedZod } from "../utils/pagination"
+import { createApi } from "../api"
+import { Pagination, getPaginatedSnakeCasedZod } from "../utils/pagination"
 
 vi.mock("axios")
 

--- a/src/utils/zod/zod.ts
+++ b/src/utils/zod/zod.ts
@@ -1,5 +1,5 @@
 import { toSnakeCase } from "@thinknimble/tn-utils"
-import { z } from "zod"
+import { ZodBranded, z } from "zod"
 import { ZodPrimitives, ZodRawShapeToSnakedRecursive, zodPrimitivesList } from "./types"
 
 export const isZod = (input: unknown): input is z.ZodSchema => {
@@ -121,7 +121,7 @@ function zodBrandToSnakeRecursive<T extends z.ZodBranded<any, any>>(zodBrand: T)
 }
 
 export const READONLY_TAG = "ReadonlyField"
-type ReadonlyTag = typeof READONLY_TAG
+export type ReadonlyTag = typeof READONLY_TAG
 export type ReadonlyField<T> = T & z.BRAND<ReadonlyTag>
 
 /**
@@ -166,6 +166,22 @@ export type StripBrand<T extends z.ZodRawShape> = {
   [K in keyof T]: T[K] extends z.ZodBranded<infer TZod, any> ? TZod : T[K]
 }
 
-export type StripReadonlyBrand<T extends z.ZodRawShape> = {
-  [K in keyof T as IsBrand<T[K], ReadonlyTag> extends true ? never : K]: T[K]
+//!Good attempt but cannot use this with generic in createApi
+export type BrandedKeys<T extends z.ZodRawShape> = keyof {
+  [K in keyof T as T[K] extends z.ZodBranded<any, any> ? K : never]: K
+}
+
+/**
+ * Strip read only brand from a type, optionally unwrap some types from brands
+ */
+export type StripReadonlyBrand<T extends z.ZodRawShape, TUnwrap extends (keyof T)[] = []> = {
+  [K in keyof T as K extends TUnwrap[number]
+    ? K
+    : IsBrand<T[K], ReadonlyTag> extends true
+    ? never
+    : K]: T[K] extends z.ZodBranded<infer TZod, any> ? TZod : T[K]
+}
+
+export type UnwrapBranded<T extends z.ZodRawShape, TBrandType extends string | number | symbol = any> = {
+  [K in keyof T]: T[K] extends ZodBranded<infer TUnwrapped, TBrandType> ? TUnwrapped : T[K]
 }


### PR DESCRIPTION
- Add some brand return type fixes
- Infer id type from entity shape rather than assuming string