### PR TITLE
`create` method now defaults its input based on `models.entity`

### DIFF
--- a/.changeset/sharp-kangaroos-breathe.md
+++ b/.changeset/sharp-kangaroos-breathe.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": minor
+---
+
+Make `create` method to always exist if there's a declared entity shape from `models`. This makes it so that if you want to use your own `create` shape in `models` you can, but that's now optional. If resolved from `entity` shape then the resulting callback signature is going to strip all readonly fields and `id` from the entity shape and use that resolved type as the input.

--- a/README.md
+++ b/README.md
@@ -317,7 +317,35 @@ When passing an `entity` model to `createApi` parameter you get a couple of buil
 
 #### `create` - Post request to create a resource
 
-Only available if you pass a `create` model
+If you passed a `create` model you would get the input type resolved from that shape. Otherwise `entity` will be used as a default
+
+Note that if `entity` shape is used to resolve the type of the input, any [readonly fields](#make-fields-readonly--only-applicable-for-entity) and `id` itself will be stripped from that type. So
+
+```typescript
+const entityShape = {
+  id: z.string().uuid(),
+  firstName: z.string(),
+  lastName: z.string(),
+  fullName: readonly(z.string()),
+}
+const api = createApi({
+  //...
+  models: {
+    entity: entityShape,
+  },
+})
+```
+
+Will result in the following call signature for the create method:
+
+```typescript
+api.create({
+  //id: stripped because it is considered readonly regardless of whether you declared it readonly or not
+  firstName: "sample first name",
+  lastName: "sample last name",
+  //fullName: stripped because it is a readonly-declared field
+})
+```
 
 #### `retrieve` - Get request to retrieve a single resource by Id
 

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -51,12 +51,14 @@ describe("createApi", async () => {
       expect(testApiNoModels).not.toHaveProperty("retrieve")
       expect(testApiNoModels).not.toHaveProperty("create")
     })
-    it("only exposes retrieve and list if only `entity` is passed", () => {
+    it("only exposes retrieve, list, update if `entity` is passed, no custom calls", () => {
       //@ts-expect-error don't mind this it is hard for TS to determine which overload it should check, on the tests below it is picking up the correct one!
       type ExpectedReturn = ReturnType<typeof createApi<{ entity: typeof entityZodShape }>>
       type tests = [
         ExpectedReturn["list"],
         ExpectedReturn["retrieve"],
+        ExpectedReturn["update"],
+        ExpectedReturn["create"],
         //@ts-expect-error should not include customServiceCalls
         ExpectedReturn["customServiceCalls"],
         //@ts-expect-error should not include  csc
@@ -70,9 +72,10 @@ describe("createApi", async () => {
           entity: entityZodShape,
         },
       })
-      expect(testApiOnlyEntity).not.toHaveProperty("create")
+      expect(testApiOnlyEntity).toHaveProperty("create")
       expect(testApiOnlyEntity).toHaveProperty("list")
       expect(testApiOnlyEntity).toHaveProperty("retrieve")
+      expect(testApiOnlyEntity).toHaveProperty("update")
       expect(testApiOnlyEntity).not.toHaveProperty("csc")
       expect(testApiOnlyEntity).not.toHaveProperty("customServiceCalls")
     })

--- a/src/utils/zod/zod.ts
+++ b/src/utils/zod/zod.ts
@@ -161,11 +161,6 @@ export type IsBrand<T extends z.ZodTypeAny, TBrand extends string> = T extends z
   ]
 }
 
-// I want that any type that has a brand attached to remove it.. so that's sort of a hard task... My initial attempt was with object. but seems that object is not enough.
-export type StripBrand<T extends z.ZodRawShape> = {
-  [K in keyof T]: T[K] extends z.ZodBranded<infer TZod, any> ? TZod : T[K]
-}
-
 //!Good attempt but cannot use this with generic in createApi
 export type BrandedKeys<T extends z.ZodRawShape> = keyof {
   [K in keyof T as T[K] extends z.ZodBranded<any, any> ? K : never]: K


### PR DESCRIPTION
Closes #91 