### PR TITLE
Remove readonly brand inference in GetInferredFromRaw util

### DIFF
--- a/.changeset/spotty-boats-heal.md
+++ b/.changeset/spotty-boats-heal.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+Fix `GetInferredFromRaw` inferring readonly brands

--- a/src/api/create-paginated-call.ts
+++ b/src/api/create-paginated-call.ts
@@ -3,7 +3,7 @@ import { Axios } from "axios"
 import { z } from "zod"
 import {
   FiltersShape,
-  GetInferredFromRaw,
+  GetInferredFromRawWithBrand,
   Pagination,
   UnknownIfNever,
   getPaginatedShape,
@@ -103,7 +103,7 @@ export function createPaginatedServiceCall<
     })
     //! although this claims not to be of the same type than our converted TOutput, it actually is, but all the added type complexity with camel casing util makes TS to think it is something different. It should be safe to cast this, we should definitely check this at runtime with tests
     const result: unknown = { ...rawResponse, results: rawResponse.results.map((r) => objectToCamelCase(r)) }
-    return result as GetInferredFromRaw<ReturnType<typeof getPaginatedShape<TOutput>>>
+    return result as GetInferredFromRawWithBrand<ReturnType<typeof getPaginatedShape<TOutput>>>
   }
   if ("inputShape" in models) {
     return {

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker"
 import { SnakeCasedPropertiesDeep, objectToCamelCase, objectToSnakeCase } from "@thinknimble/tn-utils"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRaw, InferShapeOrZod, Pagination, ReadonlyTag, UnwrapBranded, readonly } from "../../utils"
+import { GetInferredFromRaw, GetInferredFromRawWithBrand, InferShapeOrZod, Pagination, readonly } from "../../utils"
 import { createApi } from "../create-api"
 import { createCustomServiceCall } from "../create-custom-call"
 import { CustomServiceCallsRecord, ServiceCallFn } from "../types"
@@ -100,15 +100,13 @@ describe("createApi", async () => {
       mockedAxios.post.mockReset()
     })
 
-    const createInput: GetInferredFromRaw<typeof createZodShape> = {
+    const createInput: GetInferredFromRawWithBrand<typeof createZodShape> = {
       age: 19,
       lastName: "Doe",
       firstName: "Jane",
     }
     const randomId: string = faker.datatype.uuid()
-    const createResponse: SnakeCasedPropertiesDeep<
-      GetInferredFromRaw<UnwrapBranded<typeof entityZodShape, ReadonlyTag>>
-    > = {
+    const createResponse: SnakeCasedPropertiesDeep<GetInferredFromRaw<typeof entityZodShape>> = {
       age: createInput.age,
       last_name: createInput.lastName,
       first_name: createInput.firstName,
@@ -371,19 +369,19 @@ describe("TS Tests", () => {
         inputShape: tInputShape
         outputShape: tOutputShape
         filtersShape: tFiltersShape
-        callback: (params: any) => Promise<GetInferredFromRaw<tOutputShape>>
+        callback: (params: any) => Promise<GetInferredFromRawWithBrand<tOutputShape>>
       }
       noFiltersService: {
         inputShape: tInputShape
         outputShape: tOutputShape
         filtersShape: tFiltersShapeVoid
-        callback: (params: any) => Promise<GetInferredFromRaw<tOutputShape>>
+        callback: (params: any) => Promise<GetInferredFromRawWithBrand<tOutputShape>>
       }
       noInputWithFilterService: {
         inputShape: z.ZodVoid
         outputShape: tOutputShape
         filtersShape: tFiltersShape
-        callback: (params: any) => Promise<GetInferredFromRaw<tOutputShape>>
+        callback: (params: any) => Promise<GetInferredFromRawWithBrand<tOutputShape>>
       }
       justCallback: {
         inputShape: z.ZodVoid
@@ -418,7 +416,7 @@ describe("TS Tests", () => {
         Equals<
           result["noInputWithFilterService"],
           (
-            ...args: [{ filters?: Partial<GetInferredFromRaw<tFiltersShape>> }] | []
+            ...args: [{ filters?: Partial<GetInferredFromRawWithBrand<tFiltersShape>> }] | []
           ) => Promise<InferShapeOrZod<tOutputShape>>
         >
       >,
@@ -506,7 +504,7 @@ describe("TS Tests", () => {
       },
     })
     type api = typeof api
-    type unwrappedReadonlyBrands = GetInferredFromRaw<UnwrapBranded<typeof entityShape, ReadonlyTag>>
+    type unwrappedReadonlyBrands = GetInferredFromRaw<typeof entityShape>
     type tests = [
       Expect<Equals<Awaited<ReturnType<api["retrieve"]>>, unwrappedReadonlyBrands>>,
       Expect<Equals<Awaited<ReturnType<api["create"]>>, unwrappedReadonlyBrands>>,

--- a/src/api/tests/create-custom-call.test.ts
+++ b/src/api/tests/create-custom-call.test.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker"
 import { SnakeCasedPropertiesDeep, objectToSnakeCase } from "@thinknimble/tn-utils"
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRaw } from "../../utils"
+import { GetInferredFromRawWithBrand } from "../../utils"
 import { createApi } from "../create-api"
 import { createCustomServiceCall } from "../create-custom-call"
 import { mockedAxios } from "./mocks"
@@ -93,12 +93,12 @@ describe("createCustomServiceCall", () => {
         },
         async ({ input, utils }) => {
           type tests = [
-            Expect<Equals<typeof input, GetInferredFromRaw<typeof inputShape>>>,
-            Expect<Equals<(typeof utils)["fromApi"], (obj: object) => GetInferredFromRaw<typeof outputShape>>>,
+            Expect<Equals<typeof input, GetInferredFromRawWithBrand<typeof inputShape>>>,
+            Expect<Equals<(typeof utils)["fromApi"], (obj: object) => GetInferredFromRawWithBrand<typeof outputShape>>>,
             Expect<
               Equals<
                 (typeof utils)["toApi"],
-                (obj: object) => SnakeCasedPropertiesDeep<GetInferredFromRaw<typeof inputShape>>
+                (obj: object) => SnakeCasedPropertiesDeep<GetInferredFromRawWithBrand<typeof inputShape>>
               >
             >
           ]

--- a/src/api/tests/create-paginated-call.test.ts
+++ b/src/api/tests/create-paginated-call.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRaw, Pagination } from "../../utils"
+import { GetInferredFromRawWithBrand, Pagination } from "../../utils"
 import { createApi } from "../create-api"
 import { createPaginatedServiceCall } from "../create-paginated-call"
 import { entityZodShape, listResponse, mockEntity1, mockEntity2, mockedAxios } from "./mocks"
@@ -147,7 +147,7 @@ describe("createPaginatedServiceCall", () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: listResponse,
     })
-    const body: Omit<GetInferredFromRaw<(typeof testPostPaginatedServiceCall)["inputShape"]>, "pagination"> = {
+    const body: Omit<GetInferredFromRawWithBrand<(typeof testPostPaginatedServiceCall)["inputShape"]>, "pagination"> = {
       dObj: {
         dObj1: 1,
       },
@@ -181,7 +181,7 @@ describe("createPaginatedServiceCall", () => {
     mockedAxios.post.mockResolvedValueOnce({
       data: listResponse,
     })
-    const body: Omit<GetInferredFromRaw<(typeof testPostPaginatedServiceCall)["inputShape"]>, "pagination"> = {
+    const body: Omit<GetInferredFromRawWithBrand<(typeof testPostPaginatedServiceCall)["inputShape"]>, "pagination"> = {
       dObj: {
         dObj1: 1,
       },
@@ -265,8 +265,7 @@ describe("createPaginatedServiceCall", () => {
       },
     })
   })
-  it("calls api with the right filters", async () => {
-    //TODO: should probably add a couple more that check the filtering but no time atm
+  it("calls api with the right filters - no input", async () => {
     //arrange
     const testPaginatedCallWithFilters = createPaginatedServiceCall({
       outputShape: entityZodShape,

--- a/src/api/tests/mocks.ts
+++ b/src/api/tests/mocks.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker"
 import axios from "axios"
 import { Mocked, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRaw, ReadonlyField, getPaginatedSnakeCasedZod, readonly } from "../../utils"
+import { GetInferredFromRawWithBrand, ReadonlyField, getPaginatedSnakeCasedZod, readonly } from "../../utils"
 
 vi.mock("axios")
 
@@ -23,7 +23,7 @@ export const entityZodShapeWithIdNumber = {
   id: z.number(),
 }
 
-type Entity = GetInferredFromRaw<typeof entityZodShape>
+type Entity = GetInferredFromRawWithBrand<typeof entityZodShape>
 
 export const createEntityMock: () => Entity = () => {
   const firstName = faker.name.firstName()

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -5,7 +5,7 @@ import {
   And,
   CallbackUtils,
   FiltersShape,
-  GetInferredFromRaw,
+  GetInferredFromRawWithBrand,
   InferShapeOrZod,
   Is,
   IsAny,
@@ -37,9 +37,9 @@ export type CustomServiceCallFiltersObj<
 
 type InferCallbackInput<TInput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>> =
   TInput extends z.ZodRawShape
-    ? GetInferredFromRaw<TInput>
+    ? GetInferredFromRawWithBrand<TInput>
     : TInput extends z.ZodRawShape
-    ? GetInferredFromRaw<TInput>
+    ? GetInferredFromRawWithBrand<TInput>
     : TInput extends z.ZodTypeAny
     ? z.infer<TInput>
     : never

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -39,9 +39,8 @@ const createToApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArray
           : arr) as ToApiCall<T>
   }
   if (isInputZodPrimitive) return
-  return isInputZodPrimitive
-    ? undefined
-    : (((obj: object) => zodObjectToSnakeRecursive(z.object(inputShape)).parse(objectToSnakeCase(obj))) as ToApiCall<T>)
+  return ((obj: object) =>
+    zodObjectToSnakeRecursive(z.object(inputShape)).parse(objectToSnakeCase(obj))) as ToApiCall<T>
 }
 
 const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>>(

--- a/src/utils/api/types.ts
+++ b/src/utils/api/types.ts
@@ -1,18 +1,22 @@
 import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import { z } from "zod"
-import { GetInferredFromRaw, ZodPrimitives } from "../zod"
+import { GetInferredFromRawWithBrand, ZodPrimitives } from "../zod"
 
 export type ToApiCall<TInput extends z.ZodRawShape | z.ZodTypeAny> = (
   obj: object
 ) => TInput extends z.ZodRawShape
-  ? SnakeCasedPropertiesDeep<GetInferredFromRaw<TInput>>
+  ? SnakeCasedPropertiesDeep<GetInferredFromRawWithBrand<TInput>>
   : TInput extends z.ZodType
   ? z.infer<TInput>
   : never
 
 export type FromApiCall<TOutput extends z.ZodRawShape | z.ZodTypeAny> = (
   obj: object
-) => TOutput extends z.ZodRawShape ? GetInferredFromRaw<TOutput> : TOutput extends z.ZodType ? z.infer<TOutput> : never
+) => TOutput extends z.ZodRawShape
+  ? GetInferredFromRawWithBrand<TOutput>
+  : TOutput extends z.ZodType
+  ? z.infer<TOutput>
+  : never
 
 type FromApiUtil<T extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>> = {
   /**

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,13 +1,13 @@
 import { SnakeCasedPropertiesDeep, objectToSnakeCase } from "@thinknimble/tn-utils"
 import { z } from "zod"
-import { GetInferredFromRaw } from "./zod"
+import { GetInferredFromRawWithBrand } from "./zod"
 
 export const paginationFiltersZodShape = {
   page: z.number(),
   pageSize: z.number(),
 }
 
-export type PaginationFilters = GetInferredFromRaw<typeof paginationFiltersZodShape>
+export type PaginationFilters = GetInferredFromRawWithBrand<typeof paginationFiltersZodShape>
 
 type AsQueryParam<T extends object> = {
   [K in keyof T as T[K] extends string | number ? K : never]: string
@@ -24,7 +24,7 @@ export const parseFilters = <TFilters extends FiltersShape>(shape?: TFilters, fi
           if (!v) return []
           return [[k, v]]
         })
-      ) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRaw<TFilters>>>)
+      ) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRawWithBrand<TFilters>>>)
     : undefined
 }
 

--- a/src/utils/zod/types.ts
+++ b/src/utils/zod/types.ts
@@ -100,9 +100,9 @@ export type ZodPrimitives =
 type GetZodObjectType<T extends z.ZodRawShape> = ReturnType<typeof z.object<T>>
 
 /**
- * Get the resulting inferred type from a zod shape
+ * Get the resulting inferred type from a zod shape (brands are inferred as such)
  */
-export type GetInferredFromRaw<T extends z.ZodRawShape> = z.infer<GetZodObjectType<T>>
+export type GetInferredFromRawWithBrand<T extends z.ZodRawShape> = z.infer<GetZodObjectType<T>>
 
 /**
  * Strip read only brand from a type, optionally unwrap some types from brands
@@ -118,13 +118,20 @@ export type StripReadonlyBrand<T extends z.ZodRawShape, TUnwrap extends (keyof T
 /**
  * Infer the shape type, removing all the readonly fields in it.
  */
-export type GetInferredWithoutReadonlyBrands<T extends z.ZodRawShape> = GetInferredFromRaw<StripReadonlyBrand<T>>
+export type GetInferredWithoutReadonlyBrands<T extends z.ZodRawShape> = GetInferredFromRawWithBrand<
+  StripReadonlyBrand<T>
+>
+
+/**
+ * Infer the shape type, removing readonly marks and inferring their inner types
+ */
+export type GetInferredFromRaw<T extends z.ZodRawShape> = GetInferredFromRawWithBrand<UnwrapBranded<T, ReadonlyTag>>
 
 export type PartializeShape<T extends z.ZodRawShape> = {
   [K in keyof T]: z.ZodOptional<T[K]>
 }
 export type InferShapeOrZod<T extends object> = T extends z.ZodRawShape
-  ? GetInferredFromRaw<T>
+  ? GetInferredFromRawWithBrand<T>
   : T extends z.ZodTypeAny
   ? z.infer<T>
   : never


### PR DESCRIPTION
- GetInferredFromRaw no longer infers readonly brands as such, instead it yields the inner type instead