### PR TITLE
createCustomServiceCall - Allow outputShape to be array

### DIFF
--- a/.changeset/early-actors-fail.md
+++ b/.changeset/early-actors-fail.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+createCustomServiceCall - allow output shape to be of type ZodArray

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -125,7 +125,7 @@ type ToApiPlaceholder = { toApi: (obj: object) => any }
  */
 export type CustomServiceCallPlaceholder<
   TInput extends z.ZodRawShape | ZodPrimitives | z.ZodVoid = any,
-  TOutput extends z.ZodRawShape | ZodPrimitives | z.ZodVoid = any,
+  TOutput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny> | z.ZodVoid = any,
   TFilters extends FiltersShape | z.ZodVoid = any
 > = {
   inputShape: TInput


### PR DESCRIPTION
- allow output shape in custom calls to be of type zod array thus matching the same signature for create custom service call (ths probably needs to be unified across the library so that we avoid these issues)
- Remove some mocked responses that were not being consumed and thus they were leaking to other tests