### PR TITLE
Fix : Move `readonly` fn to right export. It was exporting as type 

### DIFF
--- a/.changeset/tender-mangos-switch.md
+++ b/.changeset/tender-mangos-switch.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+Fix `readonly` function being exported as type

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
 export { createApi, createCustomServiceCall, createPaginatedServiceCall } from "./api"
 export { createCollectionManager } from "./collection-manager"
-export { createApiUtils, IPagination, Pagination, PaginationDefaults, PaginationKwargs, parseResponse } from "./utils"
-export type { FromApiCall, GetInferredFromRaw, PaginationFilters, ToApiCall, readonly } from "./utils"
+export {
+  createApiUtils,
+  IPagination,
+  Pagination,
+  PaginationDefaults,
+  PaginationKwargs,
+  parseResponse,
+  readonly,
+} from "./utils"
+export type { FromApiCall, GetInferredFromRaw, PaginationFilters, ToApiCall } from "./utils"


### PR DESCRIPTION
Closes #124 

Ty @villagrat for catching this!