### PR TITLE
Fix `readonly` brand not being stripped from `create` shape override

### DIFF
--- a/.changeset/pretty-poets-eat.md
+++ b/.changeset/pretty-poets-eat.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": patch
+---
+
+Fix issue with `readonly` not properly working on Vue and other JS environments. Changed the way ZodBrand is being checked.

--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -262,8 +262,9 @@ export function createApi<
   type TApiCreate = GetInferredFromRawWithBrand<TApiCreateShape>
   const create = async (inputs: TApiCreate) => {
     const { id: _, ...entityShapeWithoutReadonlyFieldsNorId } = entityShapeWithoutReadonlyFields
+    const inputShape = "create" in models ? removeReadonlyFields(models.create) : entityShapeWithoutReadonlyFieldsNorId
     const { utils } = createApiUtils({
-      inputShape: "create" in models ? removeReadonlyFields(models.create) : entityShapeWithoutReadonlyFieldsNorId,
+      inputShape,
       name: create.name,
       outputShape: models.entity,
     })

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -180,18 +180,18 @@ describe("createApi", async () => {
         email: z.string().email(),
         firstName: z.string(),
         lastName: z.string(),
-        fullName: readonly(z.string()),
         token: readonly(z.string().nullable().optional()),
+      }
+      const createShape = {
+        ...entityShape,
+        password: z.string(),
       }
       const testApi = createApi({
         client: mockedAxios,
         baseUri: testBaseUri,
         models: {
           entity: entityShape,
-          create: {
-            ...entityShape,
-            password: z.string(),
-          },
+          create: createShape,
         },
       })
       const postSpy = vi.spyOn(mockedAxios, "post")
@@ -209,7 +209,6 @@ describe("createApi", async () => {
           email: testCreate.email,
           first_name: testCreate.firstName,
           last_name: testCreate.lastName,
-          full_name: `${testCreate.firstName} ${testCreate.lastName}`,
           token: faker.datatype.uuid(),
         },
       }

--- a/src/utils/zod/zod.ts
+++ b/src/utils/zod/zod.ts
@@ -27,10 +27,10 @@ export const isZodUnion = (input: z.ZodTypeAny): input is z.ZodUnion<readonly [z
   return input instanceof z.ZodUnion
 }
 export const isZodBrand = (input: z.ZodTypeAny): input is z.ZodBranded<any, any> => {
-  return input instanceof z.ZodBranded
+  return input._def?.typeName === "ZodBranded"
 }
 export const isZodReadonly = (input: z.ZodTypeAny): input is z.ZodBranded<any, ReadonlyTag> => {
-  return input instanceof z.ZodBranded && input.description === READONLY_TAG
+  return isZodBrand(input) && input.description === READONLY_TAG
 }
 
 //TODO: we should probably revisit the types here but they seem not too friendly to tackle given the recursive nature of this operation


### PR DESCRIPTION
## What this does
- Change the way `z.ZodBranded` is being checked. For some reason (which I am still not sure) the brand class type was removed at some point of the processing of the zod instance. This worked fine in React but in environments like Vue and RunJS this problem arose.

Closes #132 