### PR TITLE
Add flag to allow to call apis without a trailing slash.

### DIFF
--- a/.changeset/smart-gorillas-stare.md
+++ b/.changeset/smart-gorillas-stare.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": minor
+---
+
+Add chance to call built in methods without a trailing slash. TODO: type level remove restriction of axios

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -11,7 +11,6 @@ import {
   createZodShape,
   entityZodShape,
   entityZodShapeWithIdNumber,
-  entityZodShapeWithReadonlyId,
   listResponse,
   mockEntity1,
   mockEntity1Snaked,
@@ -301,6 +300,41 @@ describe("createApi", async () => {
   })
 
   describe("slash ending url", () => {
+    it("calls api with slash ending by default", async () => {
+      //arrange
+      mockedAxios.get.mockResolvedValue({ data: mockEntity1Snaked })
+      const getSpy = vi.spyOn(mockedAxios, "get")
+      const baseUri = "slashDefault"
+      const testApi = createApi({
+        baseUri,
+        client: mockedAxios,
+        models: {
+          entity: entityZodShape,
+        },
+      })
+      //act
+      await testApi.retrieve(mockEntity1Snaked.id)
+      //assert
+      expect(getSpy).toHaveBeenCalledWith(`${baseUri}/${mockEntity1Snaked.id}/`)
+    })
+    it("allows disabling slash ending uris", async () => {
+      //arrange
+      mockedAxios.get.mockResolvedValue({ data: mockEntity1Snaked })
+      const getSpy = vi.spyOn(mockedAxios, "get")
+      const baseUri = "disableSlash"
+      const testApi = createApi({
+        baseUri,
+        client: mockedAxios,
+        models: {
+          entity: entityZodShape,
+        },
+        disableTrailingSlash: true,
+      })
+      //act
+      await testApi.retrieve(mockEntity1Snaked.id)
+      //assert
+      expect(getSpy).toHaveBeenCalledWith(`${baseUri}/${mockEntity1Snaked.id}`)
+    })
     it("passes these TS tests", () => {
       createCustomServiceCall(async ({ client, slashEndingBaseUri }) => {
         type TClient = typeof client


### PR DESCRIPTION
# What this does
- allow users to opt out of built in methods trailing slash
# TODO
- Improve type layer around the trailing slash so that if we choose this option the trailing slash should no longer be type-checked