### PR TITLE
Stop obfuscation of extra fields from responses.

### DIFF
--- a/.changeset/thirty-phones-talk.md
+++ b/.changeset/thirty-phones-talk.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models-fp": minor
+---
+
+Prevent obfuscation of extra fields coming from responses. Now these fields will be available in the response (just won't be type-discoverable). Paginated calls will receive them as camelCased, whereas regular calls will receive them as they come from the raw response.

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -281,6 +281,37 @@ describe("createApi", async () => {
         },
       })
     })
+    it("should not obfuscate response fields even if they're not in the model", async () => {
+      //arrange
+      const extraField = faker.datatype.string()
+      mockedAxios.get.mockResolvedValueOnce({
+        data: {
+          count: 10,
+          next: null,
+          previous: null,
+          results: [
+            {
+              ...mockEntity1,
+              first_name: mockEntity1.firstName,
+              last_name: mockEntity1.lastName,
+              full_name: mockEntity1.fullName,
+              extra_field: extraField,
+            },
+            {
+              ...mockEntity2,
+              first_name: mockEntity2.firstName,
+              last_name: mockEntity2.lastName,
+              full_name: mockEntity2.fullName,
+              extra_field: extraField,
+            },
+          ],
+        },
+      })
+      //act
+      const result = await testApi.list()
+      //assert
+      expect(result.results[0]).toHaveProperty("extraField")
+    })
     it("verifies these ts tests", async () => {
       try {
         //use existing filter

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -60,15 +60,16 @@ const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArr
         zod: outputShape,
       })
   }
-  return isOutputZodPrimitive
-    ? undefined
-    : (((obj: object) => {
-        return parseResponse({
-          identifier: callerName,
-          data: objectToCamelCaseArr(obj) ?? {},
-          zod: z.object(outputShape),
-        })
-      }) as FromApiCall<T>)
+  //! This would send all other things that are not shapes (and not primitives) such as unions and intersections down the drain since we don't have support for those in outputShapes.
+  if (isOutputZodPrimitive) return
+  // Then it is a shape
+  return ((obj: object) => {
+    return parseResponse({
+      identifier: callerName,
+      data: objectToCamelCaseArr(obj) ?? {},
+      zod: z.object(outputShape),
+    })
+  }) as FromApiCall<T>
 }
 
 export function createApiUtils<

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -3,17 +3,23 @@ import { zodObjectToSnakeRecursive } from "./zod"
 
 //TODO: this needs cleanup. I am not happy with the usage of these across the library. Seems like we could have at least one of these less
 
-export const getPaginatedShape = <T extends z.ZodRawShape>(zodRawShape: T) => {
+export const getPaginatedShape = <T extends z.ZodRawShape>(
+  zodRawShape: T,
+  options: {
+    allowPassthrough?: boolean
+  } = { allowPassthrough: false }
+) => {
+  const zObject = options.allowPassthrough ? z.object(zodRawShape).passthrough() : z.object(zodRawShape)
   return {
     count: z.number(),
     next: z.string().nullable(),
     previous: z.string().nullable(),
-    results: z.array(zodObjectToSnakeRecursive(z.object(zodRawShape))),
+    results: z.array(zodObjectToSnakeRecursive(zObject)),
   }
 }
 
 export const getPaginatedSnakeCasedZod = <T extends z.ZodRawShape>(zodRawShape: T) =>
-  z.object(getPaginatedShape(zodRawShape))
+  z.object(getPaginatedShape(zodRawShape, { allowPassthrough: true })).passthrough()
 
 export const getPaginatedZod = <T extends z.ZodRawShape>(zodRawShape: T) =>
   z.object({

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,4 +1,5 @@
 import { z } from "zod"
+import { isZodObject } from "./zod"
 
 /**
  * Parse a backend response by providing a zod schema which will safe validate it and return the corresponding value typed. Will raise a warning if what we receive does not match our expected schema, thus we can update the schema and that will automatically update our types by inference.
@@ -15,7 +16,8 @@ export const parseResponse = <T extends z.ZodType, Z = z.infer<T>>({
   data: object
   zod: T
 }) => {
-  const parsed = zod.safeParse(data)
+  const safeParse = isZodObject(zod) ? zod.passthrough().safeParse : zod.safeParse
+  const parsed = safeParse(data)
 
   if (!parsed.success) {
     // If a request does not return what you expect, we don't let that go unnoticed, you'll get a warning that your frontend model is/has become outdated.

--- a/src/utils/tests/response.test.ts
+++ b/src/utils/tests/response.test.ts
@@ -1,0 +1,27 @@
+import { faker } from "@faker-js/faker"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { parseResponse } from "../response"
+
+describe("parseResponse", () => {
+  it("does not obfuscate extra fields if data exceeds the amount of keys that zod expects", () => {
+    //arrange
+    const data = {
+      name: faker.name.firstName(),
+      last_name: faker.name.lastName(),
+      number_of_children: faker.datatype.number({ min: 1, max: 5 }),
+    }
+    const zod = z.object({
+      name: z.string(),
+      lastName: z.string(),
+    })
+    //act
+    const parsed = parseResponse({
+      data,
+      identifier: "obfuscationTest",
+      zod,
+    })
+    //assert
+    expect(parsed).toHaveProperty("number_of_children")
+  })
+})

--- a/src/utils/zod/zod.ts
+++ b/src/utils/zod/zod.ts
@@ -108,7 +108,7 @@ export function zodObjectToSnakeRecursive<T extends z.ZodRawShape>(
       return [snakeCasedKey, resolveRecursiveZod(v)]
     })
   ) as ZodRawShapeToSnakedRecursive<T>
-  return z.object(resultingShape)
+  return zodObj._def.unknownKeys === "passthrough" ? z.object(resultingShape).passthrough() : z.object(resultingShape)
 }
 
 function zodReadonlyToSnakeRecursive<T extends z.ZodBranded<any, ReadonlyTag>>(zodBrand: T): any {


### PR DESCRIPTION
Closes #143 
- Add passthrough to parseResponse so that responses don't get their fields obfuscated.
- Add tests to both regular calls and paginated calls (which use a slightly different approach for parsing responses)

Any extra fields that come from responses will now be allowed through the zod parsing.

This creates a minor inconsistency with paginated calls and regular calls. Given that paginated calls use a custom zod (managed by this library) we are also camelcasing the unknown keys. Whereas regular calls will have the fields trickled as snake cased (since their zod is not taking them into account) 