### PR TITLE
Move to @thinknimble/tn-models

### DIFF
--- a/.changeset/rude-ducks-rule.md
+++ b/.changeset/rude-ducks-rule.md
@@ -1,0 +1,9 @@
+---
+"@thinknimble/tn-models": major
+---
+
+Release tn-models from tn-models-fp.
+
+This is a major update and the api was completely changed in favor of a better type layer support for typescript users.
+
+Please read the docs at [our repo](https://github.com/thinknimble/tn-models-fp) for more information as to how can this new version be used.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@thinknimble/tn-models-fp",
-  "version": "2.14.0",
-  "description": "Utilities for building front-end models.",
+  "name": "@thinknimble/tn-models",
+  "version": "1.3.1",
+  "description": "Utilities for building front-end models when using snake-cased backends.",
   "author": "Thinknimble",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
Closes #148 

From now own, the `tn-models-fp` package will become deprecated in favor of continuing with the versioning in `tn-models` instead. Starting from 2.0.0