### PR TITLE
Remove brand type from outputs, Fix misleading type error on createApi when entity is in wrong format

### DIFF
--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -181,13 +181,21 @@ type BaseApiParams = {
   disableTrailingSlash?: boolean
 }
 
+type CheckEntityIntegrity<TModels> = TModels extends { entity: any }
+  ? TModels extends { entity: { id: any } }
+    ? true
+    : "An `id` field in `entity` is required"
+  : "`entity` field is required"
+
 type ValidModelKeys = keyof { entity: unknown; create?: unknown; extraFilters?: unknown }
 type CheckModelsValidKeysPerKey<TModels> = {
   [K in keyof TModels]: K extends ValidModelKeys ? TModels[K] : "Invalid Key"
 }
-type CheckModels<TModels> = CheckModelsValidKeysPerKey<TModels> extends BaseModelsPlaceholder
-  ? CheckModelsValidKeysPerKey<TModels>
-  : "You should not pass `create` model without an `entity` model"
+type CheckModels<TModels> = CheckEntityIntegrity<TModels> extends true
+  ? CheckModelsValidKeysPerKey<TModels> extends BaseModelsPlaceholder
+    ? CheckModelsValidKeysPerKey<TModels>
+    : "You should not pass `create` model without an `entity` model"
+  : CheckEntityIntegrity<TModels>
 
 export function createApi<
   TModels extends BaseModelsPlaceholder,

--- a/src/api/create-paginated-call.ts
+++ b/src/api/create-paginated-call.ts
@@ -1,13 +1,11 @@
-import { objectToCamelCase } from "@thinknimble/tn-utils"
 import { Axios } from "axios"
 import { z } from "zod"
 import {
   FiltersShape,
-  GetInferredFromRaw,
   GetInferredFromRawWithBrand,
-  InferShapeOrZod,
   Pagination,
   UnknownIfNever,
+  UnwrapBrandedRecursive,
   getPaginatedShape,
   getPaginatedSnakeCasedZod,
   getPaginatedZod,
@@ -55,7 +53,8 @@ export function createPaginatedServiceCall<
   ...args: ResolvedCreatePaginatedServiceCallParameters<TOutput, TFilters, TInput>
 ): CustomServiceCallOpts<
   UnknownIfNever<TInput> & typeof paginationObjShape,
-  ReturnType<typeof getPaginatedZod<TOutput>>["shape"],
+  // TODO: test this callback return type
+  ReturnType<typeof getPaginatedZod<UnwrapBrandedRecursive<TOutput>>>["shape"],
   TFilters
 >
 
@@ -65,7 +64,11 @@ export function createPaginatedServiceCall<
 >(
   models: CustomServiceCallOutputObj<TOutput> & CustomServiceCallFiltersObj<TFilters, TOutput>,
   opts?: PaginatedServiceCallOptions
-): CustomServiceCallOpts<typeof paginationObjShape, ReturnType<typeof getPaginatedZod<TOutput>>["shape"], TFilters>
+): CustomServiceCallOpts<
+  typeof paginationObjShape,
+  ReturnType<typeof getPaginatedZod<UnwrapBrandedRecursive<TOutput>>>["shape"],
+  TFilters
+>
 
 export function createPaginatedServiceCall<
   TOutput extends z.ZodRawShape,

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -644,4 +644,23 @@ describe("TS Tests", () => {
     //@ts-expect-error should not expose any of these methods
     const { create, list, retrieve, remove, update } = api
   })
+  describe("Test", () => {
+    it("TS - errors on createApi for entity", () => {
+      //ts assert
+      createApi({
+        baseUri: "something",
+        client: mockedAxios,
+        //@ts-expect-error Call out on entity not being passed to models
+        models: {},
+      })
+      createApi({
+        baseUri: "something",
+        client: mockedAxios,
+        //@ts-expect-error Call out on entity not being properly formatted - should include id
+        models: {
+          entity: { nonIdField: z.string() },
+        },
+      })
+    })
+  })
 })

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -7,6 +7,7 @@ import {
   FiltersShape,
   GetInferredFromRawWithBrand,
   InferShapeOrZod,
+  InferShapeOrZodWithoutBrand,
   Is,
   IsAny,
   UnknownIfNever,
@@ -85,7 +86,7 @@ export type ServiceCallFn<
   TInput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny> = z.ZodVoid,
   TOutput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny> = z.ZodVoid,
   TFilters extends FiltersShape | z.ZodVoid = z.ZodVoid
-> = (...args: ResolveServiceCallArgs<TInput, TFilters>) => Promise<InferShapeOrZod<TOutput>>
+> = (...args: ResolveServiceCallArgs<TInput, TFilters>) => Promise<InferShapeOrZodWithoutBrand<TOutput>>
 
 type BaseUriInput<TCallType extends string = ""> = TCallType extends "StandAlone"
   ? unknown
@@ -105,7 +106,7 @@ export type CustomServiceCallback<
     CallbackUtils<TInput, TOutput> &
     CallbackInput<TInput> &
     CallbackFilters<TFilters, TOutput>
-) => Promise<InferShapeOrZod<TOutput>>
+) => Promise<InferShapeOrZodWithoutBrand<TOutput>>
 
 export type CustomServiceCallOpts<
   TInput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny> = z.ZodVoid,


### PR DESCRIPTION
Closes #116 
Closes #144 