### PR TITLE
Fix issue with `instanceof` operator yielding inconsistent results when using it in different runtimes

### DIFF
--- a/.changeset/hot-waves-deliver.md
+++ b/.changeset/hot-waves-deliver.md
@@ -1,0 +1,6 @@
+---
+"@thinknimble/tn-models": minor
+---
+
+- Fix issue with `instanceof` operator not working as expected in different nodeJS environments.
+- Replaced with a naive but more reliable implementation which uses `typeName` from `zod` to be able to tell apart zod instance types.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:dev": "vitest",
     "ci": "pnpm run lint && pnpm run test && pnpm run build",
-    "release": "pnpm run ci && changeset publish"
+    "release": "pnpm run ci && changeset publish",
+    "dev:watch": "tsup src/index.ts --format cjs,esm --dts --watch"
   },
   "repository": {
     "type": "git",

--- a/src/api/tests/create-custom-call.test.ts
+++ b/src/api/tests/create-custom-call.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { faker } from "@faker-js/faker"
-import { SnakeCasedPropertiesDeep, objectToSnakeCase } from "@thinknimble/tn-utils"
+import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRawWithBrand, objectToCamelCaseArr } from "../../utils"
+import { GetInferredFromRawWithBrand, objectToCamelCaseArr, objectToSnakeCaseArr } from "../../utils"
 import { createApi } from "../create-api"
 import { createCustomServiceCall } from "../create-custom-call"
 import { mockedAxios } from "./mocks"
@@ -350,7 +350,7 @@ describe("createCustomServiceCall", () => {
     })
     //assert
     expect(getSpy).toHaveBeenCalledWith(`${baseUri}/`, {
-      params: objectToSnakeCase(filters),
+      params: objectToSnakeCaseArr(filters),
     })
   })
   it("passes the right filters to callback: only output", async () => {
@@ -394,7 +394,7 @@ describe("createCustomServiceCall", () => {
     })
     //assert
     expect(getSpy).toHaveBeenCalledWith(`${baseUri}/`, {
-      params: objectToSnakeCase(filters),
+      params: objectToSnakeCaseArr(filters),
     })
   })
   it("does not error on not passing filters", async () => {
@@ -513,7 +513,7 @@ describe("createCustomServiceCall", () => {
       { testInput: faker.datatype.number() },
       { testInput: faker.datatype.number() },
     ]
-    const mockResponseSnake = mockResponse.map((item) => objectToSnakeCase(item))
+    const mockResponseSnake = mockResponse.map((item) => objectToSnakeCaseArr(item))
     const customCall = createCustomServiceCall(
       {
         inputShape,

--- a/src/collection-manager/collection-manager.test.ts
+++ b/src/collection-manager/collection-manager.test.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker"
-import { objectToCamelCase, objectToSnakeCase } from "@thinknimble/tn-utils"
 import axios from "axios"
 import { Mocked, beforeEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 import { createCollectionManager } from "."
 import { createApi } from "../api"
+import { objectToCamelCaseArr, objectToSnakeCaseArr } from "../utils"
 import { Pagination, getPaginatedSnakeCasedZod } from "../utils/pagination"
 
 vi.mock("axios")
@@ -40,7 +40,7 @@ const mockedPaginatedEntitySnakeCased: PaginatedEntity = {
 }
 const mockedPaginatedEntity = {
   ...mockedPaginatedEntitySnakeCased,
-  results: mockedPaginatedEntitySnakeCased.results.map((r) => objectToCamelCase(r)!),
+  results: mockedPaginatedEntitySnakeCased.results.map((r) => objectToCamelCaseArr(r)!),
 }
 
 describe("collection manager v2 tests", () => {
@@ -60,7 +60,7 @@ describe("collection manager v2 tests", () => {
   const feedFilters = {
     anExtraFilter: "my extra filter",
   }
-  const feedFiltersSnakeCased = objectToSnakeCase(feedFilters)!
+  const feedFiltersSnakeCased = objectToSnakeCaseArr(feedFilters)!
   const feedPagination = new Pagination({
     next: "https://mock.list/?page=6",
     page: 5,

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -1,6 +1,7 @@
-import { SnakeCasedPropertiesDeep, objectToSnakeCase } from "@thinknimble/tn-utils"
+import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import { z } from "zod"
 import { GetInferredFromRawWithBrand } from "./zod"
+import { objectToSnakeCaseArr } from "./api"
 
 export const paginationFiltersZodShape = {
   page: z.number(),
@@ -16,7 +17,7 @@ type AsQueryParam<T extends object> = {
 export const parseFilters = <TFilters extends FiltersShape>(shape?: TFilters, filters?: unknown) => {
   if (!filters || !shape) return
   const filtersParsed = z.object(shape).partial().parse(filters)
-  const snakedFilters = objectToSnakeCase(filtersParsed)
+  const snakedFilters = objectToSnakeCaseArr(filtersParsed)
   return snakedFilters
     ? (Object.fromEntries(
         Object.entries(snakedFilters).flatMap(([k, v]) => {

--- a/src/utils/tests/create-api-utils.test.ts
+++ b/src/utils/tests/create-api-utils.test.ts
@@ -2,10 +2,9 @@
 import { faker } from "@faker-js/faker"
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { createApiUtils, removeReadonlyFields } from "../api"
+import { createApiUtils, objectToSnakeCaseArr, removeReadonlyFields } from "../api"
 import { GetInferredFromRawWithBrand, readonly } from "../zod"
 import { mockedAxios } from "../../api/tests/mocks"
-import { objectToSnakeCase } from "@thinknimble/tn-utils"
 
 describe("createApiUtils", () => {
   it("returns undefined when both input output are primitives", () => {
@@ -142,7 +141,7 @@ describe("createApiUtils", () => {
       expo_token: expoTokenTest.expoToken,
     })
     mockedAxios.post("/api/test", toApi(expoTokenTest))
-    expect(postSpy).toHaveBeenCalledWith("/api/test", objectToSnakeCase(expoTokenTest))
+    expect(postSpy).toHaveBeenCalledWith("/api/test", objectToSnakeCaseArr(expoTokenTest))
   })
 
   it("returns fromApi when outputShape is zod array", () => {

--- a/src/utils/tests/response.test.ts
+++ b/src/utils/tests/response.test.ts
@@ -13,7 +13,7 @@ describe("parseResponse", () => {
     }
     const zod = z.object({
       name: z.string(),
-      lastName: z.string(),
+      last_name: z.string(),
     })
     //act
     const parsed = parseResponse({


### PR DESCRIPTION
## What this does
- `instanceof` is causing v weird issues in some node runtimes. seems like the bundling of this js feature is not consistent across different nodejs environments. IG: works in react, but doesn't work properly in Vue / RunJS
- Replaced `instanceof` with a sort of naive implementation that relies on typeNames of the different zod classes (since this is what we were using it for, to discriminate certain zodtypes at runtime).
- Add a dev:watch to rebuild on file change in case we want to use this for debugging purposes
- EXTRA FIX - Rm all objectToSnakeCase and objectToCamelCase that don't properly handle arrays. Use our own implementations that do recursive snake casing of objects.  TODO: move to tn-utils

Closes #152