### PR TITLE
Change way we referto zod type names to an official export

### DIFF
--- a/src/utils/zod/zod.ts
+++ b/src/utils/zod/zod.ts
@@ -16,34 +16,34 @@ export const isZod = (input: unknown): input is z.ZodSchema & { _def: { typeName
   )
 }
 export const isZodArray = (input: unknown): input is z.ZodArray<z.ZodTypeAny> => {
-  return isZod(input) && input._def?.typeName === z.ZodArray.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodArray
 }
 export const isZodObject = (input: unknown): input is z.ZodObject<z.ZodRawShape> => {
-  return isZod(input) && input._def?.typeName === z.ZodObject.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodObject
 }
 export const isZodOptional = (input: z.ZodTypeAny): input is z.ZodOptional<z.ZodTypeAny> => {
-  return isZod(input) && input._def?.typeName === z.ZodOptional.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodOptional
 }
 export const isZodNullable = (input: unknown): input is z.ZodNullable<z.ZodTypeAny> => {
-  return isZod(input) && input._def?.typeName === z.ZodNullable.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodNullable
 }
 export const isZodPrimitive = (input: unknown): input is ZodPrimitives => {
   return isZod(input) && zodPrimitivesList.some((inst) => input._def?.typeName === inst.name)
 }
 export const isZodIntersection = (input: unknown): input is z.ZodIntersection<z.ZodTypeAny, z.ZodTypeAny> => {
-  return isZod(input) && input._def?.typeName === z.ZodIntersection.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodIntersection
 }
 export const isZodUnion = (input: unknown): input is z.ZodUnion<readonly [z.ZodTypeAny]> => {
-  return isZod(input) && input._def?.typeName === z.ZodUnion.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodUnion
 }
 export const isZodBrand = (input: unknown): input is z.ZodBranded<any, any> => {
-  return isZod(input) && input._def?.typeName === z.ZodBranded.name
+  return isZod(input) && input._def?.typeName === z.ZodFirstPartyTypeKind.ZodBranded
 }
 export const isZodReadonly = (input: unknown): input is z.ZodBranded<any, ReadonlyTag> => {
   return isZod(input) && isZodBrand(input) && input.description === READONLY_TAG
 }
 export const isZodVoid = (input: unknown): input is z.ZodVoid => {
-  return isZod(input) && input._def.typeName === z.ZodVoid.name
+  return isZod(input) && input._def.typeName === z.ZodFirstPartyTypeKind.ZodVoid
 }
 
 //TODO: we should probably revisit the types here but they seem not too friendly to tackle given the recursive nature of this operation
@@ -135,10 +135,7 @@ function zodBrandToSnakeRecursive<T extends z.ZodBranded<any, any>>(zodBrand: T)
 export const READONLY_TAG = "ReadonlyField"
 export type ReadonlyTag = typeof READONLY_TAG
 export type ReadonlyField<T> = T & z.BRAND<ReadonlyTag>
-const mybrand = z.string().brand(READONLY_TAG)
 
-type result = z.infer<typeof mybrand> extends ReadonlyField<infer T> ? T : false
-//^?
 /**
  * Identity function that just brands this type so we can recognize readonly fields
  * @param zod


### PR DESCRIPTION
Previous solution appeared to work at first sight but when using this in a monorepo something about the `.name` was not bundled correctly giving off results