### PR TITLE
Remove `filters` param if there was no filters declared

### DIFF
--- a/.changeset/slimy-hairs-jog.md
+++ b/.changeset/slimy-hairs-jog.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+Fix issue with type exposing an enpty object typed filter when no extra filters were passed to models

--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -49,10 +49,13 @@ type ListCallObj<TEntity extends EntityShape, TExtraFilters extends FiltersShape
   /**
    * This calls the `{baseUri}/list` endpoint. Note that this has to be available in the api you're consuming for this method to actually work
    */
-  list: (params?: {
-    filters?: GetInferredFromRawWithBrand<TExtraFilters>
-    pagination?: IPagination
-  }) => Promise<z.infer<ReturnType<typeof getPaginatedZod<UnwrapBranded<TEntity, ReadonlyTag>>>>>
+  list: (
+    params?: IsNever<TExtraFilters> extends true
+      ? {
+          pagination?: IPagination
+        }
+      : { pagination?: IPagination; filters?: GetInferredFromRawWithBrand<TExtraFilters> }
+  ) => Promise<z.infer<ReturnType<typeof getPaginatedZod<UnwrapBranded<TEntity, ReadonlyTag>>>>>
 }
 type CreateCallObj<TEntity extends EntityShape, TCreate extends z.ZodRawShape = never> = {
   create: (

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -399,6 +399,19 @@ describe("createApi", async () => {
         //ignore
       }
     })
+    it("ts - should not include filters if no filters were passed", async () => {
+      const listApi = createApi({
+        baseUri: "test-no-filters",
+        client: mockedAxios,
+        models: {
+          entity: entityZodShape,
+        },
+      })
+      type parameters = Parameters<(typeof listApi)["list"]>[0]
+      type hasPagination = parameters extends { pagination?: any } | undefined ? true : false
+      type doesNotHaveFilters = parameters extends { filters?: any } | undefined ? true : false
+      type test = [Expect<hasPagination>, Expect<Equals<doesNotHaveFilters, false>>]
+    })
   })
 
   describe("slash ending url", () => {


### PR DESCRIPTION
I believe this is related with the following:
Closes #113 

Just checked, this seems not to be a problem anymore but it may be introduce an improvement so will close it nonetheless with this PR