### PR TITLE
Fix issue with update not returning camel cased.

### DIFF
--- a/.changeset/green-shrimps-return.md
+++ b/.changeset/green-shrimps-return.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+Fix issue with `update` not properly camel casing the return object

--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -356,9 +356,10 @@ export function createApi<
         inputShape: finalEntityShape.shape,
         outputShape: models.entity,
       },
-      cb: ({ client, input, utils }) => {
+      cb: async ({ client, input, utils }) => {
         const { id, ...body } = utils.toApi(input)
-        return client[httpMethod](`${slashEndingBaseUri}${id}${parsedEndingSlash}`, body)
+        const result = await client[httpMethod](`${slashEndingBaseUri}${id}${parsedEndingSlash}`, body)
+        return utils.fromApi(result?.data)
       },
     })
     return updateCall(parsedInput)

--- a/src/api/tests/create-api.test.ts
+++ b/src/api/tests/create-api.test.ts
@@ -533,6 +533,9 @@ describe("createApi", async () => {
     })
     it("calls update with partial and put", async () => {
       //arrange
+      mockedAxios.put.mockResolvedValueOnce({
+        data: mockEntity1Snaked,
+      })
       const putSpy = vi.spyOn(mockedAxios, "put")
       const { id, ...body } = {
         id: mockEntity1.id,
@@ -547,12 +550,32 @@ describe("createApi", async () => {
     })
     it("calls update with total and put", async () => {
       //arrange
+      mockedAxios.put.mockResolvedValueOnce({
+        data: mockEntity1Snaked,
+      })
       const putSpy = vi.spyOn(mockedAxios, "put")
       // fullName is readonly so won't be sent as parameter!
       const { id, fullName, ...body } = mockEntity1
       //act
       await api.update.replace(mockEntity1)
       expect(putSpy).toHaveBeenCalledWith(`${baseUri}/${id}/`, objectToSnakeCaseArr(body))
+    })
+    it("returns camelCased", async () => {
+      //arrange
+      mockedAxios.patch.mockResolvedValueOnce({
+        data: mockEntity1Snaked,
+      })
+      const patchSpy = vi.spyOn(mockedAxios, "patch")
+      const { id, ...body } = {
+        id: mockEntity1.id,
+        age: mockEntity1.age,
+      }
+      //act
+      const result = await api.update({
+        id,
+        ...body,
+      })
+      expect(result).toEqual(mockEntity1)
     })
   })
 })


### PR DESCRIPTION

Add missing `fromApi` call to result of `update` built-in
