### PR TITLE
Allow custom filters parser. Add a default filter parser which addresses arrays by joining elements into string

### DIFF
--- a/.changeset/sweet-fishes-march.md
+++ b/.changeset/sweet-fishes-march.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": minor
+---
+
+Add default parsing for array query params to be a joined comma separated string

--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -302,11 +302,11 @@ export function createApi<
     const pagination = params ? params.pagination : undefined
     // Filters parsing, throws if the fields do not comply with the zod schema
 
-    const filtersParsed = parseFilters(models.extraFilters, filters)
-    const paginationFilters = parseFilters(
-      paginationFiltersZodShape,
-      pagination ? { page: pagination.page, pageSize: pagination.size } : undefined
-    )
+    const filtersParsed = parseFilters({ shape: models.extraFilters, filters })
+    const paginationFilters = parseFilters({
+      shape: paginationFiltersZodShape,
+      filters: pagination ? { page: pagination.page, pageSize: pagination.size } : undefined,
+    })
     const allFilters =
       filtersParsed || paginationFilters ? { ...(filtersParsed ?? {}), ...(paginationFilters ?? {}) } : undefined
 

--- a/src/api/create-paginated-call.ts
+++ b/src/api/create-paginated-call.ts
@@ -105,7 +105,7 @@ export function createPaginatedServiceCall<
     const paginationFilters = input.pagination
       ? { page: input.pagination.page, pageSize: input.pagination.size }
       : undefined
-    const parsedPaginationFilters = parseFilters(paginationFiltersZodShape, paginationFilters) ?? {}
+    const parsedPaginationFilters = parseFilters({ shape: paginationFiltersZodShape, filters: paginationFilters }) ?? {}
     const snakedCleanParsedFilters = { ...parsedPaginationFilters, ...(parsedFilters ?? {}) }
     let res
     let parsedInput = input

--- a/src/api/tests/create-custom-call.test.ts
+++ b/src/api/tests/create-custom-call.test.ts
@@ -352,7 +352,10 @@ describe("createCustomServiceCall", () => {
     })
     //assert
     expect(getSpy).toHaveBeenCalledWith(`${baseUri}/`, {
-      params: objectToSnakeCaseArr(filters),
+      params: {
+        test_filter: filters.testFilter,
+        test_array_filter: filters.testArrayFilter.join(","),
+      },
     })
   })
   it("passes the right filters to callback: only output", async () => {

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -168,7 +168,7 @@ export const createCustomServiceCallHandler =
           : {}),
         parsedFilters:
           args && typeof args === "object" && "filters" in args
-            ? parseFilters(serviceCallOpts.filtersShape, args.filters)
+            ? parseFilters({ shape: serviceCallOpts.filtersShape, filters: args.filters })
             : undefined,
       })
     }

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -14,19 +14,40 @@ type AsQueryParam<T extends object> = {
   [K in keyof T as T[K] extends string | number ? K : never]: string
 }
 
-export const parseFilters = <TFilters extends FiltersShape>(shape?: TFilters, filters?: unknown) => {
+const defaultParser = (value: unknown) => {
+  if (typeof value === "number") return value.toString()
+  if (typeof value === "object" && Array.isArray(value)) {
+    return value.join(",")
+  }
+  if (!value) return
+  return value
+}
+
+export const parseFilters = <TFilters extends FiltersShape>({
+  customValueParser = defaultParser,
+  filters,
+  shape,
+}: {
+  shape?: TFilters
+  filters?: unknown
+  /**
+   * Parse a single filter value
+   * When not defined, a default parser is used
+   * @param value the filter value to address
+   * @returns the filter value parsed
+   */
+  customValueParser?: (value: unknown) => unknown
+}) => {
   if (!filters || !shape) return
   const filtersParsed = z.object(shape).partial().parse(filters)
   const snakedFilters = objectToSnakeCaseArr(filtersParsed)
-  return snakedFilters
-    ? (Object.fromEntries(
-        Object.entries(snakedFilters).flatMap(([k, v]) => {
-          if (typeof v === "number") return [[k, v.toString()]]
-          if (!v) return []
-          return [[k, v]]
-        })
-      ) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRawWithBrand<TFilters>>>)
-    : undefined
+  if (!snakedFilters) return
+  const entries = Object.entries(snakedFilters).flatMap(([k, v]) => {
+    const parsedValue = customValueParser(v)
+    if (!parsedValue) return []
+    return [[k, parsedValue]]
+  })
+  return Object.fromEntries(entries) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRawWithBrand<TFilters>>>
 }
 
 export type FiltersShape = Record<string, z.ZodString | z.ZodNumber | z.ZodArray<z.ZodNumber> | z.ZodArray<z.ZodString>>

--- a/src/utils/tests/filters.test.ts
+++ b/src/utils/tests/filters.test.ts
@@ -1,0 +1,72 @@
+import { faker } from "@faker-js/faker"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { parseFilters } from "../filters"
+
+describe("parseFilters", () => {
+  it("Snake cases keys", () => {
+    const shape = {
+      companyCategory: z.string(),
+    }
+    const filters = {
+      companyCategory: faker.company.catchPhraseAdjective(),
+    }
+    expect(parseFilters({ shape, filters })).toEqual({
+      company_category: filters.companyCategory,
+    })
+  })
+  it("Throws error if passing a wrong type filter", () => {
+    const shape = {
+      allNames: z.string().array(),
+    }
+    const filters = {
+      allNames: [faker.datatype.number(), faker.datatype.number()],
+    }
+    expect(() => {
+      parseFilters({ shape, filters })
+    }).toThrow()
+  })
+  it("Makes arrays into comma separated values", () => {
+    const shape = {
+      names: z.number().array(),
+    }
+    const names = [faker.datatype.number(), faker.datatype.number()]
+    const filters = {
+      names,
+    }
+    const parsedFilters = parseFilters({ shape, filters })
+    expect(parsedFilters).toEqual({ names: names.join(",") })
+  })
+  it("allows modifying the default parser", () => {
+    //trying to cover all possible types
+    const shape = {
+      regions: z.string().array(),
+      points: z.number(),
+      tier: z.string(),
+    }
+    const regions = Array.from({ length: 3 })
+      .fill(undefined)
+      .map(() => faker.datatype.string())
+    const points = faker.datatype.number()
+    const tier = faker.datatype.string()
+    const filters = {
+      regions,
+      points,
+      tier,
+    }
+    const customValueParser = (element: unknown) => {
+      if (typeof element === "string") {
+        return element + "+"
+      }
+      if (typeof element === "number") return element + "-"
+      if (typeof element === "object" && Array.isArray(element)) return element.join("/")
+      return element
+    }
+    const parsedFilters = parseFilters({ shape, filters, customValueParser })
+    expect(parsedFilters).toEqual({
+      regions: filters.regions.join("/"),
+      points: filters.points + "-",
+      tier: filters.tier + "+",
+    })
+  })
+})


### PR DESCRIPTION
Closes #173 

These are internal for the library but we can potentially lift it to users so they can control this
- Add chance to define a custom parser
- Provide a default parser for convenience