### PR TITLE
Fix issue with readonly fields breaking custom service calls when they're added to ouput shapes

### DIFF
--- a/.changeset/curly-geese-kiss.md
+++ b/.changeset/curly-geese-kiss.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+- Fix issue where using shapes with `readonly` fields in custom service calls would break `createApi` resulting custom call type.

--- a/src/api/tests/create-custom-call.test.ts
+++ b/src/api/tests/create-custom-call.test.ts
@@ -3,11 +3,11 @@ import { faker } from "@faker-js/faker"
 import { SnakeCasedPropertiesDeep } from "@thinknimble/tn-utils"
 import { describe, expect, it, vi } from "vitest"
 import { z } from "zod"
-import { GetInferredFromRawWithBrand, objectToCamelCaseArr, objectToSnakeCaseArr } from "../../utils"
+import { GetInferredFromRawWithBrand, UnwrapBrandedUnknown, objectToSnakeCaseArr, readonly } from "../../utils"
 import { createApi } from "../create-api"
 import { createCustomServiceCall } from "../create-custom-call"
 import { mockedAxios } from "./mocks"
-import { CustomServiceCallPlaceholder } from "../types"
+import { CustomServiceCallOpts, CustomServiceCallPlaceholder, InvalidEntryMessage } from "../types"
 
 describe("createCustomServiceCall", () => {
   const inputShape = {
@@ -1064,6 +1064,92 @@ describe("createCustomServiceCall", () => {
         params: { test_filter: testFilter },
       })
       expect(result).toEqual(mockResult)
+    })
+  })
+
+  describe("readonly util", () => {
+    it("TS - doesn't break custom call type if adding readonly util to output", async () => {
+      const outputShape = {
+        id: z.string().uuid(),
+        fieldWithReadonly: readonly(z.string().uuid()),
+      }
+      const customCall = createCustomServiceCall(
+        {
+          outputShape,
+        },
+        async ({ client, slashEndingBaseUri, utils }) => {
+          return utils.fromApi({})
+        }
+      )
+      const api = createApi(
+        {
+          baseUri: "test-readonly",
+          client: mockedAxios,
+        },
+        {
+          customCall,
+        }
+      )
+      api.csc.customCall
+      type CustomCall = typeof api.csc.customCall
+      type test = Expect<Equals<Equals<CustomCall, InvalidEntryMessage>, false>>
+    })
+    it("TS - doesn't break custom call type if adding readonly util to input", async () => {
+      const inputShape = {
+        id: z.string().uuid(),
+        fieldWithReadonly: readonly(z.string().uuid()),
+      }
+      const customCall = createCustomServiceCall(
+        {
+          inputShape,
+        },
+        async ({ client, slashEndingBaseUri, utils }) => {
+          return
+        }
+      )
+      const api = createApi(
+        {
+          baseUri: "test-readonly",
+          client: mockedAxios,
+        },
+        {
+          customCall,
+        }
+      )
+      api.csc.customCall
+      type CustomCall = typeof api.csc.customCall
+      type test = Expect<Equals<Equals<CustomCall, InvalidEntryMessage>, false>>
+    })
+    it("TS - doesn't break custom call type if adding readonly util to input and output", async () => {
+      const inputShape = {
+        id: z.string().uuid(),
+        fieldWithReadonly: readonly(z.string().uuid()),
+      }
+      const outputShape = {
+        id: z.string().uuid(),
+        fieldWithReadonly: readonly(z.string().uuid()),
+      }
+      const customCall = createCustomServiceCall(
+        {
+          inputShape,
+          outputShape,
+        },
+        async ({ client, slashEndingBaseUri, utils }) => {
+          return utils.fromApi({})
+        }
+      )
+      const api = createApi(
+        {
+          baseUri: "test-readonly",
+          client: mockedAxios,
+        },
+        {
+          customCall,
+        }
+      )
+      api.csc.customCall
+      type CustomCall = typeof api.csc.customCall
+      type test = Expect<Equals<Equals<CustomCall, InvalidEntryMessage>, false>>
     })
   })
 })

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -11,6 +11,7 @@ import {
   Is,
   IsAny,
   UnknownIfNever,
+  UnwrapBranded,
   ZodPrimitives,
 } from "../utils"
 
@@ -155,6 +156,8 @@ type ResolveServiceCallArgs<TInput extends z.ZodRawShape | z.ZodType, TFilters e
   ? [args: ResolveFilterArg<TFilters>] | []
   : [args: ResolveInputArg<TInput> & ResolveFilterArg<TFilters>]
 
+export type InvalidEntryMessage = "Invalid entry does not match CustomServiceCall type"
+
 /**
  * Get resulting custom service call from `createApi`
  */
@@ -168,6 +171,6 @@ export type CustomServiceCallsRecord<TOpts extends object> = TOpts extends Recor
               : ServiceCallFn<TInput, TOutput, z.ZodVoid>
             : ServiceCallFn<TInput, TOutput, z.ZodVoid>
           : ServiceCallFn<TInput, z.ZodVoid, z.ZodVoid>
-        : "Invalid entry does not match CustomServiceCall type"
+        : TOpts[K]
     }
   : "This should be a record of custom calls"

--- a/src/utils/zod/types.ts
+++ b/src/utils/zod/types.ts
@@ -163,6 +163,9 @@ export type BrandedKeys<T extends z.ZodRawShape> = keyof {
 export type UnwrapBranded<T extends z.ZodRawShape, TBrandType extends string | number | symbol = any> = {
   [K in keyof T]: T[K] extends z.ZodBranded<infer TUnwrapped, TBrandType> ? TUnwrapped : T[K]
 }
+export type UnwrapBrandedUnknown<T> = {
+  [K in keyof T]: T[K] extends z.ZodBranded<infer TUnwrapped, any> ? TUnwrapped : T[K]
+}
 
 type UnwrapBrandedInArray<
   T extends z.ZodArray<z.ZodTypeAny>,


### PR DESCRIPTION
# What this does
- Fix issue where using shapes with `readonly` fields in custom service calls would break `createApi` resulting custom call type.