### PR TITLE
Allow the possibility of disabling logs in

### DIFF
--- a/.changeset/wise-berries-worry.md
+++ b/.changeset/wise-berries-worry.md
@@ -1,0 +1,6 @@
+---
+"@thinknimble/tn-models": minor
+---
+
+- Allow disabling warning logs with `disableLoggingWarning` option
+- Try-catch all `parse` calls so that users don't just get the intelligible zod error in console.

--- a/src/api/create-api.ts
+++ b/src/api/create-api.ts
@@ -30,7 +30,7 @@ type EntityShape = z.ZodRawShape & {
 type BaseModelsPlaceholder<
   TEntity extends EntityShape = EntityShape,
   TCreate extends z.ZodRawShape = z.ZodRawShape,
-  TBuiltInFilters extends FiltersShape = FiltersShape
+  TBuiltInFilters extends FiltersShape = FiltersShape,
 > = TEntity extends EntityShape
   ?
       | (EntityModelObj<TEntity> & ExtraFiltersObj<TBuiltInFilters>)
@@ -42,7 +42,7 @@ type ApiService<
   TCreate extends z.ZodRawShape = never,
   TExtraFilters extends FiltersShape = never,
   //extending from record makes it so that if you try to access anything it would not error, we want to actually error if there is no key in TCustomServiceCalls that does not belong to it
-  TCustomServiceCalls extends object = never
+  TCustomServiceCalls extends object = never,
 > = BareApiService<TEntity, TCreate, TExtraFilters> &
   (IsNever<TCustomServiceCalls> extends true
     ? unknown
@@ -75,14 +75,14 @@ type ListCallObj<TEntity extends EntityShape, TExtraFilters extends FiltersShape
       ? {
           pagination?: IPagination
         }
-      : { pagination?: IPagination; filters?: Partial<GetInferredFromRawWithBrand<TExtraFilters>> }
+      : { pagination?: IPagination; filters?: Partial<GetInferredFromRawWithBrand<TExtraFilters>> },
   ) => Promise<z.infer<ReturnType<typeof getPaginatedZod<UnwrapBranded<TEntity, ReadonlyTag>>>>>
 }
 type CreateCallObj<TEntity extends EntityShape, TCreate extends z.ZodRawShape = never> = {
   create: (
     inputs: IsNever<TCreate> extends true
       ? Omit<GetInferredWithoutReadonlyBrands<TEntity>, "id">
-      : GetInferredWithoutReadonlyBrands<TCreate>
+      : GetInferredWithoutReadonlyBrands<TCreate>,
   ) => Promise<GetInferredFromRaw<TEntity>>
 }
 type ErrorEntityShapeMustHaveAnIdField = '[TypeError] Your entity should have an "id" field'
@@ -91,15 +91,15 @@ type UpdateCallObj<
   TInferredEntityWithoutReadonlyFields = GetInferredWithoutReadonlyBrands<TEntity>,
   TInferredIdObj = TInferredEntityWithoutReadonlyFields extends { id: infer TId }
     ? { id: TId }
-    : ErrorEntityShapeMustHaveAnIdField
+    : ErrorEntityShapeMustHaveAnIdField,
 > = {
   update: {
     /**
      * Perform a patch request with a partial body
      */
-    (inputs: Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj): Promise<
-      GetInferredFromRaw<TEntity>
-    >
+    (
+      inputs: Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj,
+    ): Promise<GetInferredFromRaw<TEntity>>
     /**
      * Perform a put request with a full body
      */
@@ -109,7 +109,7 @@ type UpdateCallObj<
        * Perform a put request with a full body
        */
       asPartial: (
-        inputs: Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj
+        inputs: Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj,
       ) => Promise<GetInferredFromRaw<TEntity>>
     }
   }
@@ -121,7 +121,7 @@ type UpsertCallObj<
   TInferredEntityWithoutReadonlyFields = GetInferredWithoutReadonlyBrands<TEntity>,
   TInferredIdObj = TInferredEntityWithoutReadonlyFields extends { id: infer TId }
     ? { id: TId }
-    : ErrorEntityShapeMustHaveAnIdField
+    : ErrorEntityShapeMustHaveAnIdField,
 > = {
   upsert(
     /**
@@ -131,49 +131,40 @@ type UpsertCallObj<
       | (IsNever<TCreate> extends true
           ? Omit<GetInferredWithoutReadonlyBrands<TEntity>, "id">
           : GetInferredWithoutReadonlyBrands<TCreate>)
-      | (Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj)
+      | (Omit<Partial<TInferredEntityWithoutReadonlyFields>, "id"> & TInferredIdObj),
   ): Promise<GetInferredFromRaw<TEntity>>
 }
 
-type WithCreateModelCall<
-  TEntity extends EntityShape = never,
-  TCreate extends z.ZodRawShape = never
-> = IsNever<TEntity> extends true
-  ? unknown
-  : IsNever<TCreate> extends true
-  ? CreateCallObj<TEntity>
-  : CreateCallObj<TEntity, TCreate>
+type WithCreateModelCall<TEntity extends EntityShape = never, TCreate extends z.ZodRawShape = never> =
+  IsNever<TEntity> extends true
+    ? unknown
+    : IsNever<TCreate> extends true
+      ? CreateCallObj<TEntity>
+      : CreateCallObj<TEntity, TCreate>
 
-type WithEntityModelCall<TEntity extends EntityShape = never> = IsNever<TEntity> extends true
-  ? unknown
-  : RetrieveCallObj<TEntity>
-type WithExtraFiltersModelCall<
-  TEntity extends EntityShape = never,
-  TExtraFilters extends FiltersShape = never
-> = IsNever<TEntity> extends true
-  ? unknown
-  : IsNever<TExtraFilters> extends true
-  ? ListCallObj<TEntity>
-  : ListCallObj<TEntity, TExtraFilters>
-type WithRemoveModelCall<TEntity extends EntityShape = never> = IsNever<TEntity> extends true
-  ? unknown
-  : { remove: (id: GetInferredFromRaw<TEntity>["id"]) => Promise<void> }
-type WithUpdateModelCall<TEntity extends EntityShape = never> = IsNever<TEntity> extends true
-  ? unknown
-  : UpdateCallObj<TEntity>
-type WithUpsertModelCall<
-  TEntity extends EntityShape = never,
-  TCreate extends z.ZodRawShape = never
-> = IsNever<TEntity> extends true
-  ? unknown
-  : IsNever<TCreate> extends true
-  ? UpsertCallObj<TEntity>
-  : UpsertCallObj<TEntity, TCreate>
+type WithEntityModelCall<TEntity extends EntityShape = never> =
+  IsNever<TEntity> extends true ? unknown : RetrieveCallObj<TEntity>
+type WithExtraFiltersModelCall<TEntity extends EntityShape = never, TExtraFilters extends FiltersShape = never> =
+  IsNever<TEntity> extends true
+    ? unknown
+    : IsNever<TExtraFilters> extends true
+      ? ListCallObj<TEntity>
+      : ListCallObj<TEntity, TExtraFilters>
+type WithRemoveModelCall<TEntity extends EntityShape = never> =
+  IsNever<TEntity> extends true ? unknown : { remove: (id: GetInferredFromRaw<TEntity>["id"]) => Promise<void> }
+type WithUpdateModelCall<TEntity extends EntityShape = never> =
+  IsNever<TEntity> extends true ? unknown : UpdateCallObj<TEntity>
+type WithUpsertModelCall<TEntity extends EntityShape = never, TCreate extends z.ZodRawShape = never> =
+  IsNever<TEntity> extends true
+    ? unknown
+    : IsNever<TCreate> extends true
+      ? UpsertCallObj<TEntity>
+      : UpsertCallObj<TEntity, TCreate>
 
 type BaseApiCalls<
   TEntity extends EntityShape = never,
   TCreate extends z.ZodRawShape = never,
-  TExtraFilters extends FiltersShape = never
+  TExtraFilters extends FiltersShape = never,
 > = WithCreateModelCall<TEntity, TCreate> &
   WithEntityModelCall<TEntity> &
   WithExtraFiltersModelCall<TEntity, TExtraFilters> &
@@ -184,12 +175,13 @@ type BaseApiCalls<
 type BareApiService<
   TEntity extends EntityShape = never,
   TCreate extends z.ZodRawShape = never,
-  TExtraFilters extends FiltersShape = never
-> = IsNever<TEntity> extends false
-  ? {
-      client: AxiosLike
-    } & BaseApiCalls<TEntity, TCreate, TExtraFilters>
-  : { client: AxiosLike }
+  TExtraFilters extends FiltersShape = never,
+> =
+  IsNever<TEntity> extends false
+    ? {
+        client: AxiosLike
+      } & BaseApiCalls<TEntity, TCreate, TExtraFilters>
+    : { client: AxiosLike }
 
 type CreateModelObj<TApiCreate extends z.ZodRawShape> = {
   /**
@@ -225,7 +217,7 @@ export const createApi = <
   TEntity extends EntityShape = never,
   TCreate extends z.ZodRawShape = never,
   TExtraFilters extends FiltersShape = never,
-  TCustomServiceCalls extends Record<string, CustomServiceCallPlaceholder> = never
+  TCustomServiceCalls extends Record<string, CustomServiceCallPlaceholder> = never,
 >(args: {
   baseUri: string
   client: AxiosInstance
@@ -237,6 +229,7 @@ export const createApi = <
   }
   options?: {
     disableTrailingSlash?: boolean
+    disableWarningLogging?: boolean
   }
 }): ApiService<TEntity, TCreate, TExtraFilters, TCustomServiceCalls> => {
   const { baseUri, client, customCalls, models, options } = args
@@ -263,7 +256,7 @@ export const createApi = <
             baseUri: slashEndingBaseUri,
             name: k,
           }),
-        ])
+        ]),
       ) as CustomServiceCallsRecord<TCustomServiceCalls>)
     : undefined
 
@@ -341,6 +334,7 @@ export const createApi = <
       identifier: list.name,
       data: res.data,
       zod: paginatedZod,
+      onError: args.options?.disableWarningLogging ? null : undefined,
     })
 
     return { ...rawResponse, results: rawResponse.results.map((r) => objectToCamelCaseArr(r)) }
@@ -370,29 +364,32 @@ export const createApi = <
     const entityWithoutReadonlyFieldsZod = z.object(entityShapeWithoutReadonlyFields)
     const finalEntityZod =
       type === "partial" ? entityWithoutReadonlyFieldsZod.partial() : entityWithoutReadonlyFieldsZod
-    type result = typeof finalEntityZod.shape
-
-    const parsedInput = finalEntityZod.parse(newValue)
-    const updateCall = createCustomServiceCall.standAlone({
-      client,
-      models: {
-        inputShape: finalEntityZod.shape,
-        outputShape: models.entity,
-      },
-      cb: async ({ client, input, utils }) => {
-        const { id, ...body } = utils.toApi(input)
-        const result = await client[httpMethod](`${slashEndingBaseUri}${id}${parsedEndingSlash}`, body)
-        //@ts-expect-error The generic aspect of this function seems not to be able to make out that utils should yield fromApi
-        return utils.fromApi(result?.data)
-      },
-    })
-    //@ts-expect-error we can ignore this since we're actually doing a hard parse
-    return updateCall(parsedInput)
+    try {
+      const parsedInput = finalEntityZod.parse(newValue)
+      const updateCall = createCustomServiceCall.standAlone({
+        client,
+        models: {
+          inputShape: finalEntityZod.shape,
+          outputShape: models.entity,
+        },
+        cb: async ({ client, input, utils }) => {
+          const { id, ...body } = utils.toApi(input)
+          const result = await client[httpMethod](`${slashEndingBaseUri}${id}${parsedEndingSlash}`, body)
+          //@ts-expect-error The generic aspect of this function seems not to be able to make out that utils should yield fromApi
+          return utils.fromApi(result?.data)
+        },
+      })
+      //@ts-expect-error we can ignore this since we're actually doing a hard parse
+      return updateCall(parsedInput)
+    } catch (e) {
+      console.error(`${updateBase.name} - error`, e)
+      throw e
+    }
   }
 
   //! this is a bit painful to look at but I feel it is a good UX so that we don't make Users go through updateBase params
   const update = async (
-    args: Partial<GetInferredFromRawWithBrand<typeof entityShapeWithoutReadonlyFields>> & { id: string }
+    args: Partial<GetInferredFromRawWithBrand<typeof entityShapeWithoutReadonlyFields>> & { id: string },
   ) => {
     return updateBase({ newValue: args, httpMethod: "patch", type: "partial" })
   }
@@ -400,17 +397,17 @@ export const createApi = <
     update,
     "replace",
     async (args: GetInferredFromRawWithBrand<typeof entityShapeWithoutReadonlyFields> & { id: string }) =>
-      updateBase({ newValue: args, httpMethod: "put", type: "total" })
+      updateBase({ newValue: args, httpMethod: "put", type: "total" }),
   )
   defineProperty(
     update.replace,
     "asPartial",
     (inputs: Partial<GetInferredWithoutReadonlyBrands<TApiEntityShape>> & { id: string }) =>
-      updateBase({ newValue: inputs, httpMethod: "put", type: "partial" })
+      updateBase({ newValue: inputs, httpMethod: "put", type: "partial" }),
   )
 
   const upsert = async (
-    args: TApiCreate | (Partial<GetInferredFromRawWithBrand<typeof entityShapeWithoutReadonlyFields>> & { id: string })
+    args: TApiCreate | (Partial<GetInferredFromRawWithBrand<typeof entityShapeWithoutReadonlyFields>> & { id: string }),
   ) => {
     if ("id" in args && args.id) {
       return updateBase({

--- a/src/api/create-paginated-call.ts
+++ b/src/api/create-paginated-call.ts
@@ -28,7 +28,7 @@ export const createPaginatedServiceCall = <
   TInput extends z.ZodRawShape | ZodPrimitives = never,
   TReturnType extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny> = ReturnType<
     typeof getPaginatedZod<UnwrapBrandedRecursive<TOutput>>
-  >["shape"]
+  >["shape"],
 >({
   inputShape,
   outputShape,
@@ -40,6 +40,10 @@ export const createPaginatedServiceCall = <
   filtersShape?: TFilters
   opts?: {
     /**
+     * Disable the logging of errors if the response type doesn't match the one expected from the library
+     */
+    disableLoggingWarning?: boolean
+    /**
      * Choose the http method you want this call to be executed as
      */
     httpMethod?: "post" | "get"
@@ -49,8 +53,8 @@ export const createPaginatedServiceCall = <
     uri?: IsNever<TInput> extends true
       ? string
       : TInput extends { urlParams: z.ZodObject<any> }
-      ? (input: z.infer<TInput["urlParams"]>) => string
-      : string
+        ? (input: z.infer<TInput["urlParams"]>) => string
+        : string
   }
 }): ResolveCustomServiceCallOpts<UnknownIfNever<TInput> & typeof paginationObjShape, TReturnType, TFilters> => {
   const uri = opts?.uri as ((input: unknown) => string) | undefined | string
@@ -108,6 +112,7 @@ export const createPaginatedServiceCall = <
       data: res.data,
       identifier: "custom-paginated-call",
       zod: paginatedZod,
+      onError: opts?.disableLoggingWarning ? null : undefined,
     })
     //! although this claims not to be of the same type than our converted TOutput, it actually is, but all the added type complexity with camel casing util makes TS to think it is something different. It should be safe to cast this, we should definitely check this at runtime with tests
     const result: unknown = { ...rawResponse, results: rawResponse.results.map((r) => objectToCamelCaseArr(r)) }

--- a/src/utils/api/api.ts
+++ b/src/utils/api/api.ts
@@ -17,7 +17,7 @@ import {
 } from "../zod"
 import { CallbackUtils, FromApiCall, ToApiCall } from "./types"
 
-//TODO: this should probably move to tn-utils but will keep it here for a quick release
+//TODO: #194 these should probably move to tn-utils but will keep it here for a quick release
 export const objectToCamelCaseArr = <T extends object>(obj: T): CamelCasedPropertiesDeep<T> => {
   if (typeof obj !== "object" || obj === null) return obj
   if (Array.isArray(obj)) return obj.map((o) => objectToCamelCaseArr(o)) as CamelCasedPropertiesDeep<T>
@@ -41,22 +41,41 @@ export const objectToSnakeCaseArr = <T extends object>(obj: T): SnakeCasedProper
 
 const createToApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>>(inputShape: T) => {
   // Given that this is under our control, we should not do safe parse, if the parsing fails means something is wrong (you're not complying with the schema you defined)
+
   if (isZodArray(inputShape)) {
-    return (arr: unknown[]) =>
-      (typeof arr?.[0] === "object"
-        ? resolveRecursiveZod(inputShape).parse(arr.map((i) => objectToSnakeCaseArr(i as object)))
-        : arr) as ToApiCall<T>
+    return ((arr: unknown[]) => {
+      try {
+        if (typeof arr?.[0] === "object") {
+          return resolveRecursiveZod(inputShape).parse(arr.map((i) => objectToSnakeCaseArr(i as object)))
+        }
+      } catch (e) {
+        console.error(`${createToApiHandler.name} - error`, e)
+        throw e
+      }
+      return arr
+    }) as ToApiCall<T>
   }
   if (isZodPrimitive(inputShape)) return
   return ((obj: object) => {
-    return zodObjectToSnakeRecursive(z.object(inputShape)).parse(objectToSnakeCaseArr(obj))
+    try {
+      const result = zodObjectToSnakeRecursive(z.object(inputShape)).parse(objectToSnakeCaseArr(obj))
+      return result
+    } catch (e) {
+      console.error(`${createToApiHandler.name} - error`, e)
+      throw e
+    }
   }) as ToApiCall<T>
 }
 
-const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>>(
-  outputShape: T,
+const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>>({
+  outputShape,
+  callerName,
+  disableLoggingWarning,
+}: {
+  outputShape: T
   callerName: string
-) => {
+  disableLoggingWarning?: boolean
+}) => {
   const isOutputZodArray = isZodArray(outputShape)
   const isOutputZodPrimitive = isZodPrimitive(outputShape)
 
@@ -67,6 +86,7 @@ const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArr
         identifier: callerName,
         data: typeof obj?.[0] === "object" && obj ? obj.map((o) => objectToCamelCaseArr(o as object)) : obj,
         zod: outputShape,
+        onError: disableLoggingWarning ? null : undefined,
       })
   }
   //! This would send all other things that are not shapes (and not primitives) such as unions and intersections down the drain since we don't have support for those in outputShapes.
@@ -77,22 +97,30 @@ const createFromApiHandler = <T extends z.ZodRawShape | ZodPrimitives | z.ZodArr
       identifier: callerName,
       data: objectToCamelCaseArr(obj) ?? {},
       zod: z.object(outputShape),
+      onError: disableLoggingWarning ? null : undefined,
     })
   }) as FromApiCall<T>
 }
 
 export function createApiUtils<
   TInput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>,
-  TOutput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>
+  TOutput extends z.ZodRawShape | ZodPrimitives | z.ZodArray<z.ZodTypeAny>,
 >(
-  args: { name: string } & (
+  args: { name: string; disableLoggingWarning?: boolean } & (
     | { inputShape: TInput; outputShape: TOutput }
     | { inputShape: TInput }
     | { outputShape: TOutput }
-  )
+  ),
 ) {
   if (!("inputShape" in args || "outputShape" in args)) return {} as CallbackUtils<TInput, TOutput>
-  const fromApi = "outputShape" in args ? createFromApiHandler(args.outputShape, args.name) : undefined
+  const fromApi =
+    "outputShape" in args
+      ? createFromApiHandler({
+          outputShape: args.outputShape,
+          callerName: args.name,
+          disableLoggingWarning: args.disableLoggingWarning,
+        })
+      : undefined
   const toApi = "inputShape" in args ? createToApiHandler(args.inputShape) : undefined
   return (
     fromApi || toApi
@@ -128,7 +156,7 @@ export const createCustomServiceCallHandler =
   async (args: unknown) => {
     const expectsInput = !isZodVoid(serviceCallOpts.inputShape)
     const hasPagination = (
-      argCheck: unknown
+      argCheck: unknown,
     ): argCheck is { pagination: Pagination } | { input: { pagination: Pagination } } =>
       Boolean(
         typeof argCheck === "object" &&
@@ -137,7 +165,7 @@ export const createCustomServiceCallHandler =
             ("input" in argCheck &&
               typeof argCheck.input === "object" &&
               argCheck.input &&
-              "pagination" in argCheck.input))
+              "pagination" in argCheck.input)),
       )
     const expectsFilters = !isZodVoid(serviceCallOpts.filtersShape)
     const utils = createApiUtils({
@@ -159,11 +187,11 @@ export const createCustomServiceCallHandler =
                 args && typeof args === "object" && "input" in args
                   ? args.input
                   : // TODO: probably can improve these below with two different type guards
-                  hasPagination(args) && !expectsInput && "pagination" in args
-                  ? { input: args.pagination }
-                  : hasPagination(args) && "input" in args
-                  ? { input: args.input }
-                  : undefined,
+                    hasPagination(args) && !expectsInput && "pagination" in args
+                    ? { input: args.pagination }
+                    : hasPagination(args) && "input" in args
+                      ? { input: args.input }
+                      : undefined,
             }
           : {}),
         parsedFilters:
@@ -180,7 +208,7 @@ export const createCustomServiceCallHandler =
 
 export const removeReadonlyFields = <T extends z.ZodRawShape, TUnwrap extends (keyof T)[] = []>(
   shape: T,
-  unwrap?: TUnwrap
+  unwrap?: TUnwrap,
 ) => {
   const nonReadonlyEntries: [key: string, value: z.ZodTypeAny][] = []
   const allEntries = Object.entries(shape)

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -22,17 +22,22 @@ export const parseFilters = <TFilters extends FiltersShape>({
   filters?: unknown
 }) => {
   if (!filters || !shape) return
-  const filtersParsed = z.object(shape).partial().parse(filters)
-  const snakedFilters = objectToSnakeCaseArr(filtersParsed)
-  return snakedFilters
-    ? (Object.fromEntries(
-        Object.entries(snakedFilters).flatMap(([k, v]) => {
-          if (typeof v === "number") return [[k, v.toString()]]
-          if (!v) return []
-          return [[k, v]]
-        })
-      ) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRawWithBrand<TFilters>>>)
-    : undefined
+  try {
+    const filtersParsed = z.object(shape).partial().parse(filters)
+    const snakedFilters = objectToSnakeCaseArr(filtersParsed)
+    return snakedFilters
+      ? (Object.fromEntries(
+          Object.entries(snakedFilters).flatMap(([k, v]) => {
+            if (typeof v === "number") return [[k, v.toString()]]
+            if (!v) return []
+            return [[k, v]]
+          }),
+        ) as SnakeCasedPropertiesDeep<AsQueryParam<GetInferredFromRawWithBrand<TFilters>>>)
+      : undefined
+  } catch (e) {
+    console.error(`${parseFilters.name} - error`)
+    throw e
+  }
 }
 
 export type FiltersShape = Record<string, z.ZodString | z.ZodNumber | z.ZodArray<z.ZodNumber> | z.ZodArray<z.ZodString>>


### PR DESCRIPTION
- wrap in try-catch all parse calls so that errors don't go unnoticed when toApi or other parsing locations are called
- Allow users to mute zod warnings which could potentially be too bloating. This can be controlled at `createApi` level as an option with `disableLoggingWarning`
