### PR TITLE
Fix issue with `outputShape` not properly unwrapping branded fields.

### DIFF
--- a/.changeset/strange-ladybugs-press.md
+++ b/.changeset/strange-ladybugs-press.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+Fix issue on `createCustomServiceCall` where outputShapes with nested ZodBranded fields would cause the types for the resulting service call function to break.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,7 +12,7 @@ import {
   IsAny,
   IsNever,
   UnknownIfNever,
-  UnwrapBranded,
+  UnwrapBrandedRecursive,
   ZodPrimitives,
 } from "../utils"
 
@@ -186,7 +186,7 @@ export type ResolveShapeOrVoid<
   output: IsNever<TOutputShape> extends true
     ? z.ZodVoid
     : TOutputShape extends z.ZodRawShape
-      ? UnwrapBranded<TOutputShape>
+      ? UnwrapBrandedRecursive<TOutputShape>
       : TOutputShape
   filters: IsNever<TOutputShape> extends true
     ? z.ZodVoid

--- a/src/utils/zod/types.ts
+++ b/src/utils/zod/types.ts
@@ -154,9 +154,6 @@ export type BrandedKeys<T extends z.ZodRawShape> = keyof {
 export type UnwrapBranded<T extends z.ZodRawShape, TBrandType extends string | number | symbol = any> = {
   [K in keyof T]: T[K] extends z.ZodBranded<infer TUnwrapped, TBrandType> ? TUnwrapped : T[K]
 }
-export type UnwrapBrandedUnknown<T> = {
-  [K in keyof T]: T[K] extends z.ZodBranded<infer TUnwrapped, any> ? TUnwrapped : T[K]
-}
 
 type UnwrapBrandedInArray<T extends z.ZodArray<z.ZodTypeAny>, TBrandType extends string | number | symbol = any> =
   T extends z.ZodArray<infer TZod>


### PR DESCRIPTION
Closes #182 

Add unwrap recursive to the output shape type resolution of the custom service calls.