### PR TITLE
Chore: Remove readonly fields from the output of custom calls causing errors on users.

### DIFF
--- a/.changeset/kind-zebras-remain.md
+++ b/.changeset/kind-zebras-remain.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+Swap strip with unwrap

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "@thinknimble/tn-models": "4.0.0"
   },
   "changesets": [
+    "kind-zebras-remain",
     "pretty-tigers-attend"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@thinknimble/tn-models": "4.0.0"
+  },
+  "changesets": [
+    "pretty-tigers-attend"
+  ]
+}

--- a/.changeset/pretty-tigers-attend.md
+++ b/.changeset/pretty-tigers-attend.md
@@ -1,0 +1,5 @@
+---
+"@thinknimble/tn-models": patch
+---
+
+Remove readonly from custom call outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @thinknimble/tn-models-fp
 
+## 4.0.1-canary.1
+
+### Patch Changes
+
+- 403194d: Swap strip with unwrap
+
 ## 4.0.1-canary.0
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @thinknimble/tn-models-fp
 
+## 4.0.1-canary.0
+
+### Patch Changes
+
+- Remove readonly from custom call outputs
+
 ## 4.0.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thinknimble/tn-models",
-  "version": "4.0.1-canary.0",
+  "version": "4.0.1-canary.1",
   "description": "Utilities for building front-end models when using snake-cased backends.",
   "author": "Thinknimble",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thinknimble/tn-models",
-  "version": "4.0.0",
+  "version": "4.0.1-canary.0",
   "description": "Utilities for building front-end models when using snake-cased backends.",
   "author": "Thinknimble",
   "license": "MIT",

--- a/src/utils/zod/types.ts
+++ b/src/utils/zod/types.ts
@@ -110,7 +110,7 @@ export type PartializeShape<T extends z.ZodRawShape> = {
   [K in keyof T]: z.ZodOptional<T[K]>
 }
 export type InferShapeOrZod<T extends object> = T extends z.ZodRawShape
-  ? GetInferredFromRawWithReadonly<T>
+  ? GetInferredFromRawWithStripReadonly<T>
   : T extends z.ZodTypeAny
     ? z.infer<T>
     : never

--- a/src/utils/zod/types.ts
+++ b/src/utils/zod/types.ts
@@ -110,7 +110,7 @@ export type PartializeShape<T extends z.ZodRawShape> = {
   [K in keyof T]: z.ZodOptional<T[K]>
 }
 export type InferShapeOrZod<T extends object> = T extends z.ZodRawShape
-  ? GetInferredFromRawWithStripReadonly<T>
+  ? GetInferredFromRaw<T>
   : T extends z.ZodTypeAny
     ? z.infer<T>
     : never


### PR DESCRIPTION
Readonly is only used for prevent showing fields for user when they do updates. There's not much point in trickling the readonly in typescript for the output. This could cause dumb type errors for the user.